### PR TITLE
Modernize /archive and single post pages

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -48,6 +48,12 @@ defaults:
       type: games
     values:
       layout: room
+  # Posts manage their own wrappers (full-bleed hero + contained body)
+  - scope:
+      path: ""
+      type: posts
+    values:
+      full_width: true
 
 # Plugins
 plugins:

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -1,35 +1,55 @@
 ---
 layout: default
 ---
-<article class="post-single">
-  <header class="post-header">
-    <h1>{{ page.title }}</h1>
-    <div class="post-meta">
-      <span class="post-author">Jason Ellis</span>
-      <span class="post-meta-sep">&middot;</span>
-      <time datetime="{{ page.date | date_to_xmlschema }}">{{ page.date | date: "%b %-d, %Y" }}</time>
-      {% assign words = content | number_of_words %}
-      {% assign minutes = words | divided_by: 250 %}
-      {% if minutes < 1 %}{% assign minutes = 1 %}{% endif %}
-      <span class="post-meta-sep">&middot;</span>
-      <span>{{ minutes }} min read</span>
+{%- assign featured_image = page.image | default: site.default_image -%}
+{%- assign words = content | number_of_words -%}
+{%- assign minutes = words | divided_by: 250 -%}
+{%- if minutes < 1 %}{%- assign minutes = 1 -%}{%- endif -%}
+
+<div class="post">
+  <header class="post-hero">
+    <div class="post-hero-bg" aria-hidden="true"></div>
+    <div class="post-hero-inner">
+      <div class="post-hero-text">
+        {% if page.categories.size > 0 %}
+        <div class="post-hero-cats">
+          {% for cat in page.categories %}
+          <a href="{{ '/archive/' | relative_url }}#{{ cat | uri_escape }}">{{ cat }}</a>
+          {% endfor %}
+        </div>
+        {% endif %}
+        <h1 class="post-hero-title">{{ page.title }}</h1>
+        <div class="post-hero-meta">
+          <span class="post-hero-author">Jason Ellis</span>
+          <span class="post-hero-dot">&middot;</span>
+          <time datetime="{{ page.date | date_to_xmlschema }}">{{ page.date | date: "%b %-d, %Y" }}</time>
+          <span class="post-hero-dot">&middot;</span>
+          <span>{{ minutes }} min read</span>
+        </div>
+      </div>
+      <div class="post-hero-img">
+        <img src="{{ featured_image | relative_url }}" alt="{{ page.title | escape }}">
+      </div>
     </div>
   </header>
 
-  <div class="post-content">
-    {% assign featured_image = page.image | default: site.default_image %}
-    <img class="post-featured-image" src="{{ featured_image | relative_url }}" alt="{{ page.title }}">
-    {{ content }}
-  </div>
+  <div class="site-wrapper">
+    <article class="post-article">
+      <div class="post-content">
+        {{ content }}
+      </div>
 
-  {% if page.categories.size > 0 %}
-  <footer class="post-footer-tags">
-    {% for cat in page.categories %}
-      <a href="{{ '/archive/' | relative_url }}">{{ cat }}</a>
-    {% endfor %}
-  </footer>
-  {% endif %}
-</article>
+      {% if page.categories.size > 0 %}
+      <footer class="post-tags">
+        <span class="post-tags-label">Filed under</span>
+        {% for cat in page.categories %}
+        <a href="{{ '/archive/' | relative_url }}#{{ cat | uri_escape }}">{{ cat }}</a>
+        {% endfor %}
+      </footer>
+      {% endif %}
+    </article>
+  </div>
+</div>
 
 <section class="recent-posts">
   <div class="site-wrapper">

--- a/_pages/archive.html
+++ b/_pages/archive.html
@@ -193,6 +193,16 @@ full_width: true
     reset({ correct: true });
   });
 
+  // deep link: /archive/#Software pre-selects that topic (used by post pages)
+  function applyHash(){
+    var h = decodeURIComponent((location.hash || '').replace(/^#/, '')).trim().toLowerCase();
+    if(!h) return;
+    var match = pills.filter(function(p){ return p.dataset.filter.toLowerCase() === h; })[0];
+    if(match && !match.classList.contains('is-active')) match.click();
+  }
+  window.addEventListener('hashchange', applyHash);
+
   reset();
+  applyHash();
 })();
 </script>

--- a/_pages/archive.html
+++ b/_pages/archive.html
@@ -1,26 +1,63 @@
 ---
 layout: default
 title: Blog
+description: "Everything I've rambled about — 200+ posts of rants, builds, games, and strong opinions, archived since 2000."
 permalink: /archive/
 full_width: true
 ---
-<div class="archive-page">
-  <div class="site-wrapper">
-    <div class="archive-filters">
-      <nav class="filter-categories">
-        <a href="#" class="filter-btn active" data-filter="all">All Posts</a>
-        <a href="#" class="filter-btn" data-filter="Rant">Rant</a>
-        <a href="#" class="filter-btn" data-filter="Games">Games</a>
-        <a href="#" class="filter-btn" data-filter="Hobbies">Hobbies</a>
-        <a href="#" class="filter-btn" data-filter="Software">Software</a>
-        <a href="#" class="filter-btn" data-filter="Political">Political</a>
-        <a href="#" class="filter-btn" data-filter="Photography">Photography</a>
-        <a href="#" class="filter-btn" data-filter="Aviation">Aviation</a>
+{%- comment -%} category pills in display order; counts pulled live from site.categories {%- endcomment -%}
+{%- assign cats = "Rant,Games,Hobbies,Software,Political,Photography,Aviation,Comedy" | split: "," -%}
+{%- assign oldest = site.posts | last -%}
+<div class="arc" id="arc">
+
+  <!-- ══════════════ HERO ══════════════ -->
+  <section class="arc-hero">
+    <div class="arc-hero-bg" aria-hidden="true"></div>
+    <div class="arc-wrap arc-hero-inner">
+      <p class="arc-eyebrow">The oubliette · est. {{ oldest.date | date: "%Y" }}</p>
+      <h1>Everything I've rambled about</h1>
+      <p class="arc-sub">
+        Two decades and change of rants, builds, games, and the occasional strong opinion —
+        all in one place. Filter by topic, search for a thread, and dig in.
+      </p>
+      <ul class="arc-stats">
+        <li><strong>{{ site.posts.size }}</strong><span>posts</span></li>
+        <li><strong>{{ oldest.date | date: "%Y" }}</strong><span>first entry</span></li>
+        <li><strong>{{ cats.size }}</strong><span>topics</span></li>
+      </ul>
+    </div>
+  </section>
+
+  <!-- ══════════════ STICKY TOOLBAR ══════════════ -->
+  <div class="arc-toolbar" id="arc-toolbar">
+    <div class="arc-wrap arc-toolbar-inner">
+      <nav class="arc-pills" aria-label="Filter posts by topic">
+        <button type="button" class="arc-pill is-active" data-filter="all" aria-pressed="true">
+          All <span class="arc-pill-count">{{ site.posts.size }}</span>
+        </button>
+        {% for cat in cats %}
+        {% assign n = site.categories[cat] | size %}
+        {% if n > 0 %}
+        <button type="button" class="arc-pill" data-filter="{{ cat }}" aria-pressed="false">
+          {{ cat }} <span class="arc-pill-count">{{ n }}</span>
+        </button>
+        {% endif %}
+        {% endfor %}
       </nav>
-      <div class="filter-search">
-        <input type="text" id="post-search" placeholder="Search posts...">
+
+      <div class="arc-search">
+        <svg class="arc-search-ico" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <circle cx="11" cy="11" r="8"></circle><line x1="21" y1="21" x2="16.65" y2="16.65"></line>
+        </svg>
+        <input type="text" id="post-search" placeholder="Search posts…" autocomplete="off" aria-label="Search posts">
+        <button type="button" class="arc-search-clear" id="arc-search-clear" aria-label="Clear search" hidden>&times;</button>
       </div>
     </div>
+  </div>
+
+  <!-- ══════════════ RESULTS ══════════════ -->
+  <div class="arc-wrap arc-grid-wrap">
+    <p class="arc-meta" id="archive-count">Showing all {{ site.posts.size }} posts</p>
 
     <div class="post-grid" id="archive-grid">
       {% for post in site.posts %}
@@ -35,81 +72,127 @@ full_width: true
       </a>
       {% endfor %}
     </div>
+
+    <div class="arc-empty" id="archive-empty" hidden>
+      <svg class="arc-empty-ico" width="42" height="42" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+        <polyline points="21 8 21 21 3 21 3 8"></polyline>
+        <rect x="1" y="3" width="22" height="5"></rect>
+        <line x1="10" y1="12" x2="14" y2="12"></line>
+      </svg>
+      <h2>Nothing in this drawer</h2>
+      <p>No posts match that topic or search. Try a different angle.</p>
+      <button type="button" class="arc-empty-reset" id="arc-empty-reset">Clear filters</button>
+    </div>
   </div>
 </div>
 
 <script>
 (function(){
-  var cards = Array.from(document.querySelectorAll('#archive-grid .post-card'));
-  var buttons = document.querySelectorAll('.filter-btn');
+  var root = document.getElementById('arc');
+  var grid = document.getElementById('archive-grid');
+  var cards = Array.prototype.slice.call(grid.querySelectorAll('.post-card'));
+  var pills = Array.prototype.slice.call(document.querySelectorAll('.arc-pill'));
   var search = document.getElementById('post-search');
+  var clearBtn = document.getElementById('arc-search-clear');
+  var countEl = document.getElementById('archive-count');
+  var emptyEl = document.getElementById('archive-empty');
+  var emptyReset = document.getElementById('arc-empty-reset');
+  var toolbar = document.getElementById('arc-toolbar');
+  var gridWrap = grid.parentElement;
+
+  var total = cards.length;
   var activeFilter = 'all';
-  var batchSize = 4;
+  var batchSize = 8;
   var initialLoad = 16;
   var visibleCount = 0;
-  var loading = false;
 
-  function getFilteredCards(){
-    var query = search.value.toLowerCase();
+  function getFiltered(){
+    var q = search.value.trim().toLowerCase();
     return cards.filter(function(card){
       var cats = card.dataset.categories || '';
-      var searchText = card.dataset.search || card.dataset.title || '';
+      var text = card.dataset.search || '';
       var matchCat = activeFilter === 'all' || cats.split(',').indexOf(activeFilter) !== -1;
-      var matchSearch = !query || searchText.indexOf(query) !== -1;
+      var matchSearch = !q || text.indexOf(q) !== -1;
       return matchCat && matchSearch;
     });
   }
 
-  function renderCards(count){
-    var filtered = getFilteredCards();
-    cards.forEach(function(card){ card.style.display = 'none'; });
+  function updateMeta(shown){
+    var q = search.value.trim();
+    var pristine = activeFilter === 'all' && !q;
+    countEl.textContent = pristine
+      ? 'Showing all ' + total + ' posts'
+      : 'Showing ' + shown + ' of ' + total + ' post' + (total === 1 ? '' : 's');
+    if(clearBtn) clearBtn.hidden = !q;
+    emptyEl.hidden = shown !== 0;
+    grid.style.display = shown === 0 ? 'none' : '';
+  }
+
+  function render(count){
+    var filtered = getFiltered();
+    cards.forEach(function(c){ c.style.display = 'none'; });
     visibleCount = Math.min(count, filtered.length);
-    for(var i = 0; i < visibleCount; i++){
-      filtered[i].style.display = '';
-    }
+    for(var i = 0; i < visibleCount; i++){ filtered[i].style.display = ''; }
+    updateMeta(filtered.length);
   }
 
   function loadMore(){
-    if(loading) return;
-    var filtered = getFilteredCards();
+    var filtered = getFiltered();
     if(visibleCount >= filtered.length) return;
-    loading = true;
-    var newCount = Math.min(visibleCount + batchSize, filtered.length);
-    for(var i = visibleCount; i < newCount; i++){
-      filtered[i].style.display = '';
+    var next = Math.min(visibleCount + batchSize, filtered.length);
+    for(var i = visibleCount; i < next; i++){ filtered[i].style.display = ''; }
+    visibleCount = next;
+  }
+
+  // when filtering/clearing while scrolled into the grid, pull the view back
+  // up to the results so you're not left staring at empty space.
+  function correctScroll(){
+    var top = gridWrap.getBoundingClientRect().top;
+    var th = toolbar.offsetHeight + 12;
+    if(top < th){
+      window.scrollTo({ top: window.scrollY + top - th, behavior: 'smooth' });
     }
-    visibleCount = newCount;
-    loading = false;
   }
 
-  function resetAndRender(){
-    renderCards(initialLoad);
+  function reset(opts){
+    render(initialLoad);
+    if(opts && opts.correct) correctScroll();
   }
 
-  // Infinite scroll
+  // infinite scroll + sticky shadow
+  var toolbarTop = 0;
+  function measure(){ toolbarTop = toolbar.getBoundingClientRect().top + window.scrollY; }
+  measure();
+  window.addEventListener('resize', measure);
   window.addEventListener('scroll', function(){
-    if((window.innerHeight + window.scrollY) >= (document.body.offsetHeight - 400)){
-      loadMore();
-    }
-  });
+    if((window.innerHeight + window.scrollY) >= (document.body.offsetHeight - 500)) loadMore();
+    toolbar.classList.toggle('is-stuck', window.scrollY > toolbarTop);
+  }, { passive: true });
 
-  // Filter buttons
-  buttons.forEach(function(btn){
-    btn.addEventListener('click', function(e){
-      e.preventDefault();
-      buttons.forEach(function(b){ b.classList.remove('active'); });
-      this.classList.add('active');
+  pills.forEach(function(p){
+    p.addEventListener('click', function(){
+      pills.forEach(function(b){ b.classList.remove('is-active'); b.setAttribute('aria-pressed', 'false'); });
+      this.classList.add('is-active');
+      this.setAttribute('aria-pressed', 'true');
       activeFilter = this.dataset.filter;
-      resetAndRender();
+      reset({ correct: true });
     });
   });
 
-  // Search
-  search.addEventListener('input', function(){
-    resetAndRender();
+  search.addEventListener('input', function(){ reset({ correct: true }); });
+  if(clearBtn) clearBtn.addEventListener('click', function(){ search.value = ''; search.focus(); reset(); });
+
+  if(emptyReset) emptyReset.addEventListener('click', function(){
+    search.value = '';
+    activeFilter = 'all';
+    pills.forEach(function(b){
+      var on = b.dataset.filter === 'all';
+      b.classList.toggle('is-active', on);
+      b.setAttribute('aria-pressed', on ? 'true' : 'false');
+    });
+    reset({ correct: true });
   });
 
-  // Initial load
-  resetAndRender();
+  reset();
 })();
 </script>

--- a/_posts/2000-01-02-fan-films-forum.md
+++ b/_posts/2000-01-02-fan-films-forum.md
@@ -5,6 +5,7 @@ title: Fan Films Forum
 description: "A farewell to the Fan Films Forum, the small online community I ran for years that brought together amateur filmmakers worldwide."
 excerpt: Amateur / Fan Films Forum was created in back in early 2000  and was made up of a small community of amateur and fan film enthusiasts.. 
 layout: page
+full_width: false
 tags:
 categories:
 image: /assets/images/2009/10/fff.png

--- a/_sass/_archive.scss
+++ b/_sass/_archive.scss
@@ -1,0 +1,281 @@
+// ════════════════════════════════════════════════════════════════
+//  Blog archive — /archive
+//  Scoped under `.arc`. The post cards reuse the shared global
+//  .post-grid / .post-card (unchanged); only the chrome around them
+//  lives here. Palette inherits the site: #2673da accent, Nunito Sans.
+// ════════════════════════════════════════════════════════════════
+
+$arc-accent:  #2673da;
+$arc-accent-2:#4a9aff;
+$arc-ink:     #1c2330;
+$arc-body:    #3a3f4b;
+$arc-muted:   #6b7280;
+$arc-faint:   #9aa1ad;
+$arc-line:    #e3e6ea;
+$arc-bg:      #f2f2f2;
+$arc-mono:    "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+
+.arc {
+  *, *::before, *::after { box-sizing: border-box; }
+
+  .arc-wrap {
+    max-width: 1000px;
+    margin: 0 auto;
+    padding: 0 2rem;
+  }
+
+  // ════════════════ HERO ════════════════
+  .arc-hero {
+    position: relative;
+    background: radial-gradient(120% 150% at 82% -20%, #1e3a6b 0%, #141a2b 55%, #0d111c 100%);
+    color: #fff;
+    padding: 2.6rem 0 2.3rem;
+    overflow: hidden;
+    border-bottom: 3px solid $arc-accent;
+  }
+  .arc-hero-bg {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    background:
+      radial-gradient(38% 60% at 10% 15%, rgba(38,115,218,0.30) 0%, transparent 60%),
+      radial-gradient(34% 50% at 96% 100%, rgba(74,154,255,0.20) 0%, transparent 60%);
+    &::after {
+      content: "";
+      position: absolute;
+      inset: 0;
+      background-image:
+        linear-gradient(rgba(255,255,255,0.04) 1px, transparent 1px),
+        linear-gradient(90deg, rgba(255,255,255,0.04) 1px, transparent 1px);
+      background-size: 42px 42px;
+      mask-image: radial-gradient(circle at 50% 20%, #000 0%, transparent 78%);
+    }
+  }
+  .arc-hero-inner { position: relative; }
+  .arc-eyebrow {
+    text-transform: uppercase;
+    letter-spacing: 0.16em;
+    font-size: 0.7rem;
+    font-weight: 700;
+    color: rgba(255,255,255,0.62);
+    margin: 0 0 0.5rem;
+  }
+  .arc-hero h1 {
+    font-size: clamp(1.9rem, 1.2rem + 2.6vw, 2.8rem);
+    font-weight: 800;
+    line-height: 1.04;
+    letter-spacing: -0.02em;
+    margin: 0 0 0.6rem;
+    color: #fff;
+    background: linear-gradient(180deg, #ffffff 0%, #cdd9f0 100%);
+    -webkit-background-clip: text;
+    background-clip: text;
+    -webkit-text-fill-color: transparent;
+  }
+  .arc-sub {
+    font-size: 1.02rem;
+    line-height: 1.6;
+    color: rgba(255,255,255,0.8);
+    margin: 0 0 1.4rem;
+  }
+  .arc-stats {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1.75rem;
+    li {
+      display: flex;
+      align-items: baseline;
+      gap: 0.4rem;
+      position: relative;
+      &:not(:last-child)::after {
+        content: "";
+        position: absolute;
+        right: -0.9rem;
+        top: 0.25rem;
+        bottom: 0.25rem;
+        width: 1px;
+        background: rgba(255,255,255,0.16);
+      }
+    }
+    strong {
+      font-family: $arc-mono;
+      font-size: 1.5rem;
+      font-weight: 700;
+      color: #fff;
+      line-height: 1;
+    }
+    span {
+      font-size: 0.7rem;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: rgba(255,255,255,0.6);
+    }
+  }
+
+  // ════════════════ STICKY TOOLBAR ════════════════
+  .arc-toolbar {
+    position: sticky;
+    top: 0;
+    z-index: 30;
+    background: rgba(247,248,250,0.92);
+    backdrop-filter: blur(8px);
+    border-bottom: 1px solid $arc-line;
+    transition: box-shadow 0.2s ease;
+    &.is-stuck { box-shadow: 0 6px 22px rgba(18,22,34,0.08); }
+  }
+  .arc-toolbar-inner {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    padding: 0.7rem 2rem;
+    flex-wrap: wrap;
+  }
+  .arc-pills {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.4rem;
+  }
+  .arc-pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    font: inherit;
+    font-size: 0.8rem;
+    font-weight: 600;
+    color: $arc-body;
+    background: #fff;
+    border: 1px solid $arc-line;
+    border-radius: 999px;
+    padding: 0.32rem 0.55rem 0.32rem 0.8rem;
+    cursor: pointer;
+    line-height: 1.4;
+    transition: border-color 0.15s ease, color 0.15s ease, background 0.15s ease, transform 0.12s ease;
+    &:hover { border-color: rgba(38,115,218,0.5); color: $arc-accent; }
+    &:active { transform: translateY(1px); }
+    &.is-active {
+      background: $arc-accent;
+      border-color: $arc-accent;
+      color: #fff;
+    }
+  }
+  .arc-pill-count {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 1.4rem;
+    font-family: $arc-mono;
+    font-size: 0.68rem;
+    font-weight: 600;
+    line-height: 1;
+    color: $arc-muted;
+    background: #eef1f5;
+    border-radius: 999px;
+    // top-heavy padding offsets the mono font's empty descent so the digit
+    // sits at the optical centre of the bubble rather than riding high
+    padding: 0.38rem 0.45rem 0.14rem;
+    transition: background 0.15s ease, color 0.15s ease;
+  }
+  .arc-pill:hover .arc-pill-count { background: #e4ebf7; color: $arc-accent; }
+  .arc-pill.is-active .arc-pill-count { background: rgba(255,255,255,0.22); color: #fff; }
+
+  .arc-search {
+    position: relative;
+    display: flex;
+    align-items: center;
+    flex: 0 1 250px;
+  }
+  .arc-search-ico {
+    position: absolute;
+    left: 0.7rem;
+    color: $arc-faint;
+    pointer-events: none;
+  }
+  .arc-search input {
+    width: 100%;
+    font: inherit;
+    font-size: 0.85rem;
+    color: $arc-ink;
+    padding: 0.45rem 1.9rem 0.45rem 2.1rem;
+    border: 1px solid $arc-line;
+    border-radius: 999px;
+    background: #fff;
+    transition: border-color 0.15s ease, box-shadow 0.15s ease;
+    &::placeholder { color: $arc-faint; }
+    &:focus {
+      outline: none;
+      border-color: $arc-accent;
+      box-shadow: 0 0 0 3px rgba(38,115,218,0.15);
+    }
+  }
+  .arc-search-clear {
+    position: absolute;
+    right: 0.5rem;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 1.25rem;
+    height: 1.25rem;
+    border: 0;
+    border-radius: 50%;
+    background: #e7eaef;
+    color: $arc-muted;
+    font-size: 1rem;
+    line-height: 1;
+    cursor: pointer;
+    transition: background 0.15s ease, color 0.15s ease;
+    &:hover { background: $arc-accent; color: #fff; }
+    &[hidden] { display: none; }
+  }
+
+  // ════════════════ RESULTS ════════════════
+  .arc-grid-wrap { padding-top: 0.25rem; }
+  .arc-meta {
+    font-size: 0.78rem;
+    color: $arc-muted;
+    margin: 1rem 0 0;
+    padding-bottom: 0.25rem;
+    font-weight: 600;
+    letter-spacing: 0.01em;
+  }
+
+  // the shared .post-grid already paints the cards; just tighten the top gap
+  #archive-grid { padding-top: 0.75rem; }
+
+  // ════════════════ EMPTY STATE ════════════════
+  .arc-empty {
+    text-align: center;
+    padding: 3.5rem 1rem 4rem;
+    &[hidden] { display: none; }
+    .arc-empty-ico { display: block; margin: 0 auto 0.7rem; color: $arc-faint; }
+    h2 { font-size: 1.3rem; color: $arc-ink; margin: 0 0 0.4rem; }
+    p { color: $arc-muted; margin: 0 0 1.25rem; }
+  }
+  .arc-empty-reset {
+    font: inherit;
+    font-size: 0.85rem;
+    font-weight: 700;
+    color: #fff;
+    background: $arc-accent;
+    border: 0;
+    border-radius: 999px;
+    padding: 0.55rem 1.4rem;
+    cursor: pointer;
+    transition: background 0.15s ease, transform 0.12s ease;
+    &:hover { background: #1a5ab8; }
+    &:active { transform: translateY(1px); }
+  }
+}
+
+@media (max-width: 620px) {
+  .arc .arc-toolbar-inner { gap: 0.6rem; }
+  .arc .arc-search { flex-basis: 100%; order: 2; }
+  .arc .arc-pills { order: 1; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .arc *, .arc-toolbar { transition: none !important; scroll-behavior: auto !important; }
+}

--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -724,49 +724,7 @@
   &:hover { color: #333; }
 }
 
-// ── Archive page ────────────────────────────────────────
-.archive-page {
-  padding-top: 1.5rem;
-}
-
-.archive-filters {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  flex-wrap: wrap;
-  gap: 1rem;
-  margin-bottom: 1.5rem;
-}
-
-.filter-categories {
-  display: flex;
-  gap: 0.4rem;
-  flex-wrap: wrap;
-}
-
-.filter-btn {
-  font-size: 0.8rem;
-  padding: 0.35rem 0.85rem;
-  border: 1px solid #ccc;
-  border-radius: 3px;
-  color: #555;
-  background: #fff;
-  cursor: pointer;
-  &:hover { border-color: #999; color: #222; text-decoration: none; }
-  &.active { background: #2673da; color: #fff; border-color: #2673da; }
-}
-
-.filter-search {
-  input {
-    font-size: 0.85rem;
-    padding: 0.4rem 0.75rem;
-    border: 1px solid #ccc;
-    border-radius: 3px;
-    width: 200px;
-    font-family: inherit;
-    &:focus { outline: none; border-color: #2673da; }
-  }
-}
+// ── Archive page lives in _sass/_archive.scss (scoped under .arc) ──
 
 // ── Resume page ─────────────────────────────────────────
 .resume-links-row {

--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -348,51 +348,8 @@
 }
 
 // ── Single post ─────────────────────────────────────────
-.post-single {
-  background: #fff;
-  max-width: 1000px;
-  margin: 0 auto;
-  padding: 2.5rem;
-  border: 1px solid #ddd;
-  border-radius: 2px;
-}
-
-.post-header {
-  margin-bottom: 1.5rem;
-
-  h1 {
-    font-size: 1.8rem;
-    margin: 0 0 0.5rem;
-    line-height: 1.25;
-    color: #222;
-  }
-
-  .post-meta {
-    font-size: 0.85rem;
-    color: #999;
-    display: flex;
-    align-items: center;
-    gap: 0.4rem;
-    flex-wrap: wrap;
-  }
-
-  .post-author {
-    color: #555;
-    font-weight: 500;
-  }
-
-  .post-meta-sep {
-    color: #ccc;
-  }
-}
-
-.post-featured-image {
-  float: right;
-  width: 50%;
-  margin: 0 0 1rem 1.5rem;
-  border-radius: 4px;
-}
-
+// The post hero + article card live in _sass/_post.scss (scoped .post).
+// The shared body type styles stay here as .post-content.
 .post-content {
   font-size: 1.05rem;
   line-height: 1.8;
@@ -409,22 +366,6 @@
 
   blockquote {
     border-left: 3px solid #2673da;
-  }
-}
-
-.post-footer-tags {
-  padding-top: 1rem;
-  border-top: 1px solid #eee;
-
-  a {
-    display: inline-block;
-    background: #f0f0f0;
-    padding: 0.25rem 0.75rem;
-    border-radius: 3px;
-    font-size: 0.8rem;
-    margin: 0.2rem;
-    color: #555;
-    &:hover { background: #2673da; color: #fff; }
   }
 }
 

--- a/_sass/_post.scss
+++ b/_sass/_post.scss
@@ -1,0 +1,156 @@
+// ════════════════════════════════════════════════════════════════
+//  Single post — split hero + article, scoped under `.post`.
+//  The body still uses the shared .post-content / .recent-posts rules;
+//  this file owns the hero band, the article card, and the tag pills.
+// ════════════════════════════════════════════════════════════════
+
+$po-accent:  #2673da;
+$po-accent-2:#4a9aff;
+$po-ink:     #1c2330;
+$po-line:    #ddd;
+
+.post {
+  *, *::before, *::after { box-sizing: border-box; }
+
+  // ════════════════ SPLIT HERO ════════════════
+  .post-hero {
+    position: relative;
+    background: radial-gradient(120% 150% at 82% -20%, #1e3a6b 0%, #141a2b 55%, #0d111c 100%);
+    color: #fff;
+    overflow: hidden;
+    border-bottom: 3px solid $po-accent;
+    padding: 2.6rem 0;
+  }
+  .post-hero-bg {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    background:
+      radial-gradient(38% 60% at 10% 15%, rgba(38,115,218,0.30) 0%, transparent 60%),
+      radial-gradient(34% 50% at 96% 100%, rgba(74,154,255,0.20) 0%, transparent 60%);
+    &::after {
+      content: "";
+      position: absolute;
+      inset: 0;
+      background-image:
+        linear-gradient(rgba(255,255,255,0.04) 1px, transparent 1px),
+        linear-gradient(90deg, rgba(255,255,255,0.04) 1px, transparent 1px);
+      background-size: 42px 42px;
+      mask-image: radial-gradient(circle at 50% 20%, #000 0%, transparent 78%);
+    }
+  }
+  .post-hero-inner {
+    position: relative;
+    max-width: 1000px;
+    margin: 0 auto;
+    padding: 0 2rem;
+    display: flex;
+    align-items: center;
+    gap: 2.5rem;
+    @media (max-width: 760px) {
+      flex-direction: column-reverse;
+      align-items: flex-start;
+      gap: 1.4rem;
+    }
+  }
+  .post-hero-text { flex: 1; min-width: 0; }
+  .post-hero-img {
+    flex: 0 0 400px;
+    @media (max-width: 760px) { flex-basis: auto; width: 100%; }
+    img {
+      width: 100%;
+      aspect-ratio: 3 / 2;           // native cover ratio — no cropping
+      object-fit: cover;
+      border-radius: 14px;
+      box-shadow: 0 20px 44px rgba(0,0,0,0.4);
+      border: 1px solid rgba(255,255,255,0.12);
+      display: block;
+    }
+  }
+
+  .post-hero-cats {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.4rem;
+    margin-bottom: 0.7rem;
+    a {
+      font-size: 0.66rem;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.1em;
+      color: #fff;
+      background: rgba(38,115,218,0.85);
+      padding: 0.22rem 0.65rem;
+      border-radius: 999px;
+      text-decoration: none;
+      transition: background 0.15s ease;
+      &:hover { background: $po-accent; }
+    }
+  }
+  .post-hero-title {
+    font-size: clamp(1.9rem, 1.2rem + 2.6vw, 2.9rem);
+    font-weight: 800;
+    line-height: 1.06;
+    letter-spacing: -0.02em;
+    margin: 0 0 0.7rem;
+    color: #fff;
+    background: linear-gradient(180deg, #ffffff 0%, #cdd9f0 100%);
+    -webkit-background-clip: text;
+    background-clip: text;
+    -webkit-text-fill-color: transparent;
+  }
+  .post-hero-meta {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 0.55rem;
+    font-size: 0.85rem;
+    color: rgba(255,255,255,0.7);
+    .post-hero-author { color: #fff; font-weight: 600; }
+    .post-hero-dot { opacity: 0.5; }
+  }
+
+  // ════════════════ ARTICLE CARD ════════════════
+  .post-article {
+    background: #fff;
+    border: 1px solid $po-line;
+    border-radius: 2px;
+    max-width: 1000px;
+    margin: 1.5rem auto 0;
+    padding: 2.5rem;
+    @media (max-width: 600px) { padding: 1.5rem; }
+  }
+  // first heading/paragraph shouldn't add extra top space inside the card
+  .post-content > :first-child { margin-top: 0; }
+
+  // ════════════════ TAG PILLS ════════════════
+  .post-tags {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    margin-top: 2rem;
+    padding-top: 1.25rem;
+    border-top: 1px solid #eee;
+    .post-tags-label {
+      font-size: 0.72rem;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: #999;
+      margin-right: 0.15rem;
+    }
+    a {
+      font-size: 0.8rem;
+      font-weight: 600;
+      color: $po-accent;
+      background: #eef3fb;
+      border: 1px solid #dbe6f7;
+      padding: 0.26rem 0.8rem;
+      border-radius: 999px;
+      text-decoration: none;
+      transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease;
+      &:hover { background: $po-accent; color: #fff; border-color: $po-accent; }
+    }
+  }
+}

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -8,3 +8,4 @@
 @use "investments";
 @use "about";
 @use "archive";
+@use "post";

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -7,3 +7,4 @@
 @use "paradroid";
 @use "investments";
 @use "about";
+@use "archive";


### PR DESCRIPTION
Continues the site modernization (after the `/about` refresh) by giving **`/archive`** and **single post pages** the same hero language. Two self-contained commits.

## `/archive` — modern chrome around the post cards
The post cards are unchanged; everything around them got the treatment:
- **Dark gradient hero** with a stat strip (post count · first-entry year · topic count), pulled live from site data.
- **Sticky, blurred toolbar** — category pills now carry **live per-topic counts** (and `Comedy` is no longer orphaned), a modernized icon search with a clear (×) button, and a shadow once stuck.
- **Live "showing X of N posts"** result line + a proper **empty state** (line-art drawer icon + Clear filters) instead of silently blanking the grid.
- Scroll-correction so filtering while scrolled keeps results in view.
- New `_sass/_archive.scss` scoped under `.arc`; removes the dead `.archive-page`/`.filter-*` rules.

## Single posts — split hero
- **Full-bleed dark hero**: title, category pills, and author/date/read-time on the left; the **cover image at native 3:2 (uncropped)** framed on the right. Stacks cleanly on mobile.
- Drops the old in-body floated featured image — the hero carries it now. Body sits in a clean white card.
- Footer **"Filed under" pills deep-link to the archive filtered by topic** (`/archive/#Software`); the archive reads the hash on load.
- Posts default to `full_width` so the hero can go edge-to-edge; the one legacy `layout: page` post is pinned with `full_width: false`.
- New `_sass/_post.scss` scoped under `.post`; removes the dead `.post-single`/`.post-header`/`.post-featured-image`/`.post-footer-tags` rules.

## Verification
Headless (Chromium): filter/search/empty-state/clear/sticky all work on `/archive`; post hero renders at a 3:2 ratio and `/archive/#Software` pre-filters to 24 posts; **0 JS errors**; responsive to 390px. Build is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
