### PR TITLE
Blend the home hero portrait into the page

### DIFF
--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -143,7 +143,15 @@
 
 // ── Homepage hero ───────────────────────────────────────
 .home-hero {
-  background: #000;
+  // Blend the half-face portrait into the page: the gradient holds the
+  // photo's own backdrop colours at its edges (#060505 on the left,
+  // #020202 on the right) then drifts to a faint navy behind the text.
+  background: linear-gradient(90deg,
+    #060505 0%,
+    #060505 15%,
+    #020202 34%,
+    #020202 54%,
+    #04060f 100%);
   padding: 0;
 
   .hero-inner {
@@ -160,10 +168,19 @@
   }
 
   .profile-image {
-    width: 234px;
-    height: 234px;
+    width: 250px;
+    height: 250px;
     object-fit: cover;
     flex-shrink: 0;
+    // feather the portrait's dark right side into the background so the
+    // face dissolves toward the text instead of sitting in a hard box
+    -webkit-mask-image: linear-gradient(90deg, #000 68%, transparent 100%);
+    mask-image: linear-gradient(90deg, #000 68%, transparent 100%);
+
+    @media (max-width: 700px) {
+      -webkit-mask-image: none;
+      mask-image: none;
+    }
   }
 
   .hero-text {


### PR DESCRIPTION
Touches just the **home hero top area** so the half-face portrait blends into the page instead of sitting in a hard box on flat black.

- Background goes from flat `#000` to a horizontal gradient anchored to the photo's own backdrop colors — `#060505` at its left edge, `#020202` at its right — then a faint navy drift behind the text (ties the home hero to the navy heroes elsewhere on the site).
- The portrait's shadowed right side is feathered into the background and sized up slightly, so the face emerges from the darkness rather than living in a 234px box. The mask is disabled on the mobile stacked layout.
- **Hero text is unchanged** — same yellow name, site name, and tagline.

One-file change (`_sass/_layout.scss`). Verified headless across desktop + mobile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
