### PR TITLE
Refresh home nav/sub-hero + rework footer

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -20,9 +20,11 @@
           <nav class="nav-links">
             <a href="{{ '/about/' | relative_url }}">About Me</a>
             <a href="{{ '/archive/' | relative_url }}">Blog</a>
+            <a href="{{ '/games/' | relative_url }}">Games</a>
             <a href="{{ '/investments/' | relative_url }}">Investments</a>
             <!-- <a href="{{ '/rv-10/' | relative_url }}">RV-10</a> -->
             <!-- <a href="{{ '/bicolline/' | relative_url }}">Bicolline</a> -->
+            <a href="https://www.etsy.com/shop/CJWOODTREASURES" target="_blank" rel="noopener">Etsy Store</a>
           </nav>
           <div id="resume-slot" class="resume-slot"></div>
           <div class="social-icons">
@@ -150,14 +152,6 @@
   </main>
 
   <footer class="site-footer">
-    <div class="footer-social-bar">
-      <a href="https://www.facebook.com/jason.r.ellis" target="_blank" rel="noopener"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"/></svg> Facebook</a>
-      <a href="https://twitter.com/JasonEllis72" target="_blank" rel="noopener"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M23.953 4.57a10 10 0 01-2.825.775 4.958 4.958 0 002.163-2.723c-.951.555-2.005.959-3.127 1.184a4.92 4.92 0 00-8.384 4.482C7.69 8.095 4.067 6.13 1.64 3.162a4.822 4.822 0 00-.666 2.475c0 1.71.87 3.213 2.188 4.096a4.904 4.904 0 01-2.228-.616v.06a4.923 4.923 0 003.946 4.827 4.996 4.996 0 01-2.212.085 4.936 4.936 0 004.604 3.417 9.867 9.867 0 01-6.102 2.105c-.39 0-.779-.023-1.17-.067a13.995 13.995 0 007.557 2.209c9.053 0 13.998-7.496 13.998-13.985 0-.21 0-.42-.015-.63A9.935 9.935 0 0024 4.59z"/></svg> Twitter</a>
-      <a href="http://www.linkedin.com/in/jasonellis" target="_blank" rel="noopener"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433c-1.144 0-2.063-.926-2.063-2.065 0-1.138.92-2.063 2.063-2.063 1.14 0 2.064.925 2.064 2.063 0 1.139-.925 2.065-2.064 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z"/></svg> LinkedIn</a>
-      <a href="https://www.youtube.com/c/JasonEllisBuilds/" target="_blank" rel="noopener"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M23.498 6.186a3.016 3.016 0 00-2.122-2.136C19.505 3.545 12 3.545 12 3.545s-7.505 0-9.377.505A3.017 3.017 0 00.502 6.186C0 8.07 0 12 0 12s0 3.93.502 5.814a3.016 3.016 0 002.122 2.136c1.871.505 9.376.505 9.376.505s7.505 0 9.377-.505a3.015 3.015 0 002.122-2.136C24 15.93 24 12 24 12s0-3.93-.502-5.814zM9.545 15.568V8.432L15.818 12l-6.273 3.568z"/></svg> Youtube</a>
-      <a href="https://www.patreon.com/palamedes" target="_blank" rel="noopener"><svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M15.386.524c-4.764 0-8.64 3.876-8.64 8.64 0 4.75 3.876 8.613 8.64 8.613 4.75 0 8.614-3.864 8.614-8.613C24 4.4 20.136.524 15.386.524zM.003 23.476h4.22V.524H.003v22.952z"/></svg> Patreon</a>
-    </div>
-
     <div class="footer-photo-strip">
       <div class="strip-track">
         {% for i in (1..25) %}
@@ -256,6 +250,9 @@
             <h3>About Me</h3>
             <p>Hey everyone! Glad to see you here. Welcome to my peripheral brain on the internet, the virtual oubliette of crap where I store my thoughts, feelings and opinions. Lots to read if you're so inclined.</p>
             <a href="{{ '/about/' | relative_url }}" class="read-more">Read More</a>
+            <div class="footer-about-social">
+              {% include social-icons.html %}
+            </div>
           </div>
         </div>
       </div>
@@ -266,9 +263,6 @@
         <div class="footer-bottom-inner">
           <p class="footer-copy">&copy; 1997 by Random String of Words on RSOW.com</p>
           <a href="#" class="back-to-top">&#9650;</a>
-          <div class="footer-bottom-social">
-            {% include social-icons.html %}
-          </div>
         </div>
       </div>
     </div>

--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -217,40 +217,30 @@
   }
 }
 
-// ── Sub-hero bar ────────────────────────────────────────
+// ── Sub-hero accent bar ─────────────────────────────────
+// A thin blue rule that separates the dark hero from the content.
+// (Nav moved up into the site header; the posts heading sits below.)
 .sub-hero {
+  height: 6px;
   background: #2673da;
-  padding: 0.5rem 0;
+}
 
-  .sub-hero-inner {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    flex-wrap: wrap;
-    gap: 0.5rem;
-  }
+// ── "Most Recent Blog Posts" heading ────────────────────
+.recent-posts-heading {
+  font-size: 1.45rem;
+  font-weight: 700;
+  color: #333;
+  margin: 1.6rem 0 0.25rem;
+  letter-spacing: -0.01em;
 
-  .sub-hero-label {
-    font-size: 20px;
-    font-weight: 200;
-    color: #fff;
-    white-space: nowrap;
-  }
-
-  .sub-hero-nav {
-    display: flex;
-    gap: 0.4rem;
-    flex-wrap: wrap;
-
-    a {
-      font-size: 0.75rem;
-      font-weight: 500;
-      color: #fff;
-      padding: 0.25rem 0.65rem;
-      border: 1px solid rgba(255,255,255,0.5);
-      border-radius: 3px;
-      &:hover { background: rgba(255,255,255,0.2); border-color: #fff; }
-    }
+  &::after {
+    content: "";
+    display: block;
+    width: 48px;
+    height: 3px;
+    margin-top: 0.5rem;
+    background: #2673da;
+    border-radius: 2px;
   }
 }
 
@@ -427,27 +417,7 @@
 // ── Footer ──────────────────────────────────────────────
 .site-footer {
   margin-top: 0;
-}
-
-.footer-social-bar {
-  background: #2673da;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  gap: 2rem;
-  padding: 0.75rem 1rem;
-  flex-wrap: wrap;
-
-  a {
-    color: #fff;
-    font-size: 0.85rem;
-    display: inline-flex;
-    align-items: center;
-    gap: 0.4rem;
-    &:hover { color: #e0e0e0; text-decoration: none; }
-
-    svg { fill: currentColor; }
-  }
+  border-top: 6px solid #2673da;
 }
 
 .footer-photo-strip {
@@ -622,6 +592,24 @@
       &:hover { color: #4a9aff; }
     }
   }
+
+  .footer-about-social {
+    display: flex;
+    gap: 0.55rem;
+    margin-top: 0.9rem;
+
+    .social-icon {
+      width: 32px;
+      height: 32px;
+      border-radius: 50%;
+      background: rgba(255,255,255,0.1);
+      color: #fff;
+      transition: background 0.15s ease, transform 0.15s ease;
+      &:hover { background: #2673da; transform: translateY(-2px); }
+
+      svg { width: 15px; height: 15px; }
+    }
+  }
 }
 
 .footer-bottom {
@@ -646,20 +634,6 @@
     color: #999;
     font-size: 1rem;
     &:hover { color: #fff; text-decoration: none; }
-  }
-
-  .footer-bottom-social {
-    display: flex;
-    gap: 0.5rem;
-
-    .social-icon {
-      color: #999;
-      width: 22px;
-      height: 22px;
-      &:hover { color: #fff; }
-
-      svg { width: 14px; height: 14px; }
-    }
   }
 }
 

--- a/index.html
+++ b/index.html
@@ -16,22 +16,10 @@ full_width: true
     </div>
   </section>
 
-  <div class="sub-hero">
-    <div class="site-wrapper sub-hero-inner">
-      <span class="sub-hero-label">Most Recent Blog Posts:</span>
-      <nav class="sub-hero-nav">
-        <a href="{{ '/about/' | relative_url }}">About Me</a>
-        <a href="{{ '/archive/' | relative_url }}">Blog</a>
-        <a href="{{ '/games/' | relative_url }}">Games</a>
-        <a href="{{ '/investments/' | relative_url }}">Investments</a>
-        <!-- <a href="{{ '/rv-10/' | relative_url }}">RV-10</a> -->
-        <!-- <a href="{{ '/bicolline/' | relative_url }}">Bicolline</a> -->
-        <a href="https://www.etsy.com/shop/CJWOODTREASURES" target="_blank" rel="noopener">Etsy Store</a>
-      </nav>
-    </div>
-  </div>
+  <div class="sub-hero" aria-hidden="true"></div>
 
   <div class="site-wrapper">
+    <h2 class="recent-posts-heading">Most Recent Blog Posts</h2>
     <div class="post-grid">
       {% for post in paginator.posts %}
       <a class="post-card" href="{{ post.url | relative_url }}">


### PR DESCRIPTION
## Home page
- **Consolidated nav into the global top menu** — `Games` and `Etsy Store` now live in the site header alongside About Me / Blog / Investments (so they appear site-wide, not just on the home page).
- **Slimmed the sub-hero blue bar** to a thin 6px accent rule under the hero (was a full bar holding a duplicate nav + label).
- **Moved "Most Recent Blog Posts"** out of the bar into a proper section heading above the post grid, with a short blue underline.

## Footer (Option C)
- **Removed the standalone flat blue social bar** at the top of the footer.
- **Folded the social icons into the "About Me" block** as round icon buttons that fill blue on hover.
- **Dropped the duplicate social icon row** in the copyright bar (social now appears exactly once).
- **Added a 6px blue top border to `<footer>`**.

## Verification
`jekyll build` clean; home + footer render at 200; social icons appear once (in the About block); no leftover `.footer-social-bar` / `.footer-bottom-social`. Throwaway `/footermock/` comparison page removed.