### PR TITLE
Restyle subluxation post's legacy comments as iMessage-style bubbles

### DIFF
--- a/_posts/2008-01-25-subluxation-a-chiropractic-crock-of-shit.md
+++ b/_posts/2008-01-25-subluxation-a-chiropractic-crock-of-shit.md
@@ -164,673 +164,532 @@ In the mean time, I'm out $300 and my neck still hurts.
 
 ---
 
-####Legacy Comments
-
-
-<i class='icon-star'></i> Jason - January 25th, 2008 at 1:43 PM
-
-      Addendum; I’m willing to concede that there are likely some chiropractors that aren’t complete fakes. But the methods they employ MUST be radically different than the ones I have seen so far.
-
-
-Stephen Barrett, MD - January 25th, 2008 at 2:35 PM
-
-      What happened to you is quite common. The leg-length/subluxation hoopla is part of “Activator Methods,” which we describe at http://www.chirobase.org/06DD/activator.html
-
-
-Calvin - January 25th, 2008 at 4:30 PM
-
-      “It really pisses me off that in the United States people can lie, and sell you snake oil and there is no law against it. It should be illegal. But the simple fact is, if someone plays on your fears or desires and bilks you out of money you’re just out that money.”
-
-      -Generally we refer to these people as politicians. I think we’re used to this type of treatment in the political arena and we’ve pretty much come to expect it. When this comes at us from the medical arena it sort of disturbs the sensibilities. I mean this isn’t the 19th century any more. But hey at least he didn’t sell you a bottle of heroin or prescribe trepanation.
-
-
-userandabuser - March 5th, 2008 at 1:52 PM
-
-      my name is Nick, and my girlfriend is going through the same exact thing here in port st. lucie,fla. Just as you said “as soon as I entered the office my bullshit meter skyrockets and my spider sences are telling me to get out of there quick.” but my girlfriends parents are paying for the “treatments” so its my job to stay with my girl while he hits her with the clickie thing. so long story short, I’ve been to this office several times and it has very thin walls and one can hear into the next room quite well, and as far as I can tell everyone in this office has the same problem because everyone gets the same exact treatment. I got the one leg is shorter explination also and like you said my girls back still hurts after months of treatments and she has even developed new problems but hey one leg is shorter than the other right?
-
-
-<i class='icon-star'></i> Jason - March 5th, 2008 at 3:06 PM
-
-    Nick, get out while you can. The problem here is that the illusion of care that this “doctor” is giving does nothing. And your girl friend could actually be hurt or in danger.
-
-    Take her to a real doctor before whatever the problem is, gets worse.
-
-
-~M~ - April 2nd, 2008 at 7:46 AM
-
-      Hi Jason! I have just recently falling into this same situation and have been deciding what my best move is. I am wondering did u ever see a MD? What did they do for you & how is your neck feeling now? Thanks so much!! ~M~
-
-
-<i class='icon-star'></i> Jason - April 16th, 2008 at 9:20 PM
-
-      Well at this point, I’m doing fine.
-
-      Ultimately I let time do the healing.. which is all that would have happend had I let the “doctor” help me.
-
-      I eventually went and saw a real MD and she basicallys aid that this was one of those things that’d go away with time.
-
-      I hope you’re feeling better.. Good luck.
-
-
-N - April 21st, 2008 at 10:15 AM
-
-      That sucks you had such a negative experience.
-      I go to a couple of Chiros down here in Aus and they’ve been great for my back treatment. They really address the pain and compared to the MDs who only give me drugs, they really know their shit at what they do to target the pain. They’ve been excellent by me and seem to care alot more than the doctors i’ve been to so I wouldn’t go as far as making broad generalisations about the entire practise.
-      I’ve been to a doctor before who googled my symptoms onto the computer in front of me! I just swear by chiropractic, maybe you should just see a different one?
-
-
-<i class='icon-star'></i> Jason - April 22nd, 2008 at 10:25 PM
-
-      N, the issue I have is that other folks I have talked to feel the same way I do. Most think they are complete charlatans.
-
-      I mean I was trying to be open minded about them when I went to one, but my experiences to date haven’t been good.
-
-      If others find value in the service that they provide then so be it. I don’t know if your chiropractor is selling you good feelings or if he’s actually doing something to help you. (Or hell if selling you good feelings IS the something that helps you).. but for my part, they weren’t doing anything of any value to me.
-
-      I’d be hard pressed to go to another chiropractor at this point. I mean they aren’t cheap after all..
-
-
-Zoo Knudsen - June 21st, 2008 at 6:38 PM
-
-      You should see what they do with kids, especially the anti-vaccination rhetoric they are so fond of. Oh, I’m sorry, the pro-information about vaccines rhetoric. Unfortunately their information is probably what Jenny McCarthy earned her Google Ph.D with. I enjoyed reading your post Jason. The sad thing is that you don’t even know how really bad things are in the world of chiropractic, but you’ve got a decent inkling.
-
-      What is the difference between a Doctor and a Chiropractor you ask? Doctors don’t call themselves chiropractors.
-
-
-<i class='icon-star'></i> Jason - June 22nd, 2008 at 11:41 AM
-
-      It really makes you wonder how this industry has lasted as long as it has..
-
-
-Shawn Lauriat - June 22nd, 2008 at 12:24 PM
-
-      People believe in reincarnation, believe that their children will burn alive through all eternity unless they save them through rituals and punishment, and believe they can get healed over the telephone.
-
-      In contrast, chiropractors probably seem like educated doctors.
-
-
-Craig - October 28th, 2008 at 1:04 PM
-
-      You have to realize that there are lying scumbags in every profession. There happens to be a lot in the chiropractic profession. However, there are also very good chiropractors who treat from a strictly evidence based musculoskeletal perspective using a combination of commonly accepted techniques (myofascial release, massage, traction, mobilization, adjustment, physiotherapy modalities and exercise prescription). Someone in this post said the quacks use the term ‘subluxation’ and this is essentially true. That’s the easiest way to differentiate a good chiropractor from a quack (obviously this is a rough guide). Anyways, I’ve had great relief from chiropractic treatment and nothing hokey was done to me or asked of me. I was asked about the pain and history of the injury, I underwent a full physical assessment and I was treated the same day and it only cost me $50 for the first visit and $25 for the next two visits that I needed. That’s it. You know that most professional sports franchises employ chiropractors to treat their athletes. Most amateur / olympic athletes see chiropractors. These are people that know their shit when it comes to health and fitness. The take home point is that there are bad apples everywhere and you have to be a smart consumer, even when it comes to health care. Do your research but keep an open mind.
-
-
-Andrea - November 22nd, 2008 at 12:13 PM
-
-      OMG – It’s like you just wrote my story! These scam artist chiropractors must go to the same con school. I got the exact same spiel, right down to the Christopher Reeve story. I went in for HEADACHES (my con man ran an ad in the local paper for relief from headaches)and by the time I left his office he had convinced me I had arthritis in my neck and a dowagers hump! Oh and my right leg was 1 inch shorter than my left leg! I was basically told I needed immediate intensive treatment,which cost $10,000 but if I signed up for his plan today,he would reduce price to $4,000 and i could make payments. Of course i signed, he was very smooth con man, but as soon as I got home I realized i had been duped and I called his office and cancelled the contract, but not before he had charged me $350.00 for the first visit! People, please do your research when it comes to chiropractors, I’m sure there are some good ones, but from my research (after the fact)I have found that they typically run the same scam. Jason, Thank you so much for posting your story. I felt really stupid and embarrased after i fell for this, but reading your post has shown me that it wasn’t me, I am not stupid! These guys are running a scam and you are helping to expose it and helping “victims” of this chiropractic scam to see the light! Thank you!
-
-
-J. Patrick McCarver, D.C. - December 21st, 2008 at 8:22 PM
-
-      Hello Jason, Sorry to hear about your experience at that chiropractor. The real problem in your story is two-fold: 1. The chiropractor never told you what was going on and what his role was in you getting better, and 2. you,being like most of us, wanting quick relief from whatever ails you. So if you would allow me a little of time I will try to explain what that other chiro was afraid to. Chiropractic doesn’t operate in the same field with tradition allopathic or alternative medicine. Both of these are concerned with treating your disease or symptom. Chiropractic is concerned with removing interference in your nervous system(NS). Chiropractic is not a “cure” for neck or back pain (or anything else for that matter). Your NS is the master control center for everything your body does. We only work with the back and neck because that is where your spinal cord is. I hate that you feel that all chiros are bad because of this guy, I mean I’ve been screwed over by a computer guy before, but that doesn’t that you are no good at what you do. Listen, it’s really simple, Subluxation is the term used to describe a vertebrae that is misaligned and causing interference to the NS. The job of the chiro is to remove the interference and allow the to function normally. I will readily admit that there are lots of shady chiros out there. If you ever go to one of us again, beware of anything that is mentioned beyond removing interferce to your NS. Back to comment about quick relief. Most of the problems we have with health is due to this problem. We don’t listen to our bodies anymore, we believe that every symptom is something to get rid of. Symptoms are typically your body’s way of telling you that something is wrong, that are not the problem. It would be like me replacing my moniter every time I got an error message on the screen. Health and healing take time, chiropractic helps the body do that better. I hope this helps in some way, if not I would be more than willing to talk to you personally, feel free to e-mail me.
-
-
-<i class='icon-star'></i> Jason - January 12th, 2009 at 10:01 AM
-
-      Thanks for your input Patrick I do appreciate it.
-
-      If chiropractic doesn’t operate in the same field with traditional allopathic or alternative medicine, then why do you call yourself a doctor? What form of medicine is it then? Is it medicine at all? More over, most D.C.’s actually go out of their way to show that their “cures” rival or even surpass any cure that you might find via modern medicine.
-
-      Your own marketing schemes and methodologies however makes your “science” smack of snake oil. Some sort of cure all that will solve all your ails if only you did this one thing, for the low low price of… over the course of months and months…
-
-      Chiropractic may concern itself with my nervous system, but I maintain that the activator method using that little thumper device can do absolutely nothing to adjust my spine, or to use your words, “remove interference in my nervous system”. Any comment to the opposite is pure shenanigans..
-
-      And while yes, “Subluxation” is technically a medical term its use in this manner is not only erroneous but misleading. A subluxation is a “partial dislocation”, and if someone has dislocated their spine then nothing you do will help. If you have a subluxation of the spine then the last thing you need is some jackass with a “hammer” fixing it. Used in the manner that it’s used by the chiropractic community, it’s designed not to educate but rather used as a term to scare and bewilder.. “Oh Noes, the ‘doctor’ is using a scary medical term that I don’t understand… I must need his help…”
-
-      You have been screwed over by one computer guy, but don’t blame all computer guys. Fair enough. Whats interesting is that there isn’t a larger belief that computer guys will screw you.. Yet when I tell my chiropractor story a lot of folks chime in with similar stories. So a lot of folks are getting screwed around by chiropractors.. No so much with computer guys huh..
-
-      So is that a failing in your industry that it attracts so many bad practitioners? Of the probably 100 people I have told this story to, a good 50% of them had a similar story and more knew of someone with a similar story.
-
-      You readily admit there are a lot of shady chiro’s out there.. that’s amusing because I don’t readily admit there are a lot of shady computer guys.. in fact I haven’t run across very many.. I’m sure they exist but they aren’t any where near as apparent as people of your profession.
-
-      Finally, I leave you with the same thing that I always find amusing.. Chiropractors always call themselves doctors. Doctors (of medicine) never call themselves chiropractors. I wonder why that is..
-
-      To use your words “Chiropractic is not a cure for neck or back pain, or anything else for that matter.” Excellent! I couldn’t have said it better.
-
-
-Brian - January 12th, 2009 at 10:13 AM
-
-      Sorry for those that had a bad experience. I went to a chiropractor when I was 18 because I was getting migraines for my whole life. I saw all kinds of MD’s and neurologist who gave me drugs that didnt work. The chiropractor adusted me 8 times and I’ve never had a headache again. I recommend people to chiropractors a lot and most seem to have a very favorable experience. I’d keep searching for a good chiropractor. Good luck!
-
-
-<i class='icon-star'></i> Jason - January 12th, 2009 at 10:23 AM
-
-      See that’s the issue Brian, I think it’s pretty tough to find a “good chiropractor”. So far I’m pretty sure there is no such thing. My opinion, and the opinion of the majority of the folks I talk to is that they sell “good feelings” (placebo effect at best).
-
-      If “good feelings” works for you then so be it, but that sort of thing doesn’t help me. Snake oil sells and sells well.. The more they realize that, and the more honest folks are duped into buying into it … “your left leg is longer than the right.. oh noes!” … they more they will do it. People will continue to pay to cure things that don’t need to be cured.
-
-      It was said on the radio yesterday that a chiropractor is suing someone over his blog posts claiming defamation..
-
-      Being litigious about a profession that a lot of folks already see as a scam only makes it stink that much more.. it’s bad business simply because it’s bad PR furthering opinions like mine.
-
-
-Kelly - February 12th, 2009 at 12:52 AM
-
-      I think it is sad that our health insurance companies help pay for these quaks to take advantage of people. I am sure that it makes everyone’s rates increase as a result. The whole profession should be illegal. It is nothing but a pseudoscience that reeks of fraud. People would heal just as well given enough time, but chiropractors like to take the credit for the body’s “innate ability to heal itself.” From my experience, chiropractic is ineffective at best and at worst it could potentially do harm.
-
-
-Chris Allen - February 19th, 2009 at 9:47 PM
-
-      OMG.. thanks for your story. I laughed my ass off! I went for the first time yesterday and my bullshit meter was off the charts. I had to go back again today for the consult on the xrays. I wont’ be going back!
-
-
-Larry Mirous - September 15th, 2009 at 12:40 PM
-
-      This story is so true, I just came back from the chiroprator, which I am a non-believer, but thought I give it a chance because of a lower sore back which I have had before because of marathon running and it has come at the worst time because the Chicago Marathon is only 4 weeks away. The same thing happen to me, $185.00 for x-rays and then the next vist the next day was to be $45 for an adjustment which I went to and then I was told come in every day for the next two weeks, I’m unemployed, it did not matter, and she also has people coming in watching videos on subluxation, the choice I made right then and there was to get the hell out of there while I still had money for groceries and my mortgage.
-
-
-al nixon - September 29th, 2009 at 4:57 PM
-
-      Jason, Right choice, not going back. I went once, in 1968, and ended up having a stroke.
-
-
-<i class='icon-star'></i> Jason - September 29th, 2009 at 5:33 PM
-
-      OH god thats aweful..
-
-
-Dr. Dalton RN, DC - October 24th, 2009 at 3:47 AM
-
-      Chiropractic has helped many people. Chiropractic has helped people that has had no luck with their medical treatments. Chiropractic is not for everyone. Have you ever heard of the “Mind and Body Connection?” Well, If you believe that you will never get well then you will not. If you believe that something bad will happen to you in life, then it probably will. And no, chiropractic is not medicine that’s why it is called Chiropractic. I’m sorry for those of you that have had a bad experience. I have had bad experiences with some of my past dentist, medical doctors, lawyers, etc. Instead of bad mouthing those professions, I went out and found what works for me. The doctor asked this person about falls as a child or abuse as a child because those childhood physical injuries can manifest 20 years later causing early degeneration of your spine. Chiropractic is not witch craft and one has to understand the anatomy and physiology of the body very well to understand the concept. Maybe the doctor did not do a good job of explaining. Your body needs time to adjust to the treatments provided. You can not expect for a few treatment to cure a problem that has been going on for 20 years. The patients that did not respond well to care in my office are usually the ones that missed several appointments and did not do the exercises or stretches as I asked. In my office, If I feel that I am unable to help a patient I will refer them to someone else and not waste anyone’s time or money.
-
-      Do you really think that the government or insurance companies would pay for witchcraft. No, they pay because chiropractic has helped many people and there is a need for this type of care. Everyone is not a good candidate for traditional surgery or medications. There is a time and place for every form of health care, you just have to find what works for you. Every single medication has side effects. Every surgery has risks. Studies have shown that the chances of strokes after cervical manipulation is very rare and about 1 per 1 million patients. There are many delicate chiropractic treatments and screening tests to rule out patients that may not be able to tolerate certain types of cervical manipulation. You do not have to be a medical doctor to be considered a “real doctor”.
-
-      I have worked in the Veterans hospital with people in tremendous pain and immobility and watched them decrease the use of their pain medications and become more mobile. These patients greatly appreciate or services so much that the military and veterans hospitals are expanding our services.
-
-
-<i class='icon-star'></i> Jason - October 24th, 2009 at 10:11 PM
-
-      You’re right in that you don’t have to be a medical doctor to be considered a real doctor.. I know someone who has their doctorate in computer science (I think its CS anyway).. He doesn’t insist we call him Doctor either, even though he certainly has the right.. He also went to something like 20 years of schooling to get that doctorate.. How much does the average DC go through? OH and one other important point, he isn’t trying to fool anyone into thinking that he is a medical doctor..
-
-      “If you believe that you will never get well then you will not. If you believe that something bad will happen to you in life, then it probably will.”
-
-      Again, you have to believe chiropractic methodology works, for it to work.. If you believe it doesn’t work, it wont work.. At best, that’s called the placebo effect.. You’re convincing them that you’re doing something to make them better.. You have to “believe” in chiropractic for it to work.. Sort of like a religion that uses “faith healing”.. its basically the same thing..
-
-      You sell good feelings.. You try to convince people that they are getting better by performing (in your words, not mine) witchcraft.. You use big words like “subluxation” and funking little devices over them, then charge them outrageous fees..
-
-      Were we a couple hundred years in the past you’d be shaking a chicken foot over their head..
-
-      And as I said above, THAT’S NOT MEDICINE.. If I don’t believe in penicillin or even Advil, it still works.. Yet I have to “believe” for your cure to work.. Hrmmm..
-
-      At best, you’re selling those people a placebo and the placebo effect is doing the work that you’re taking credit for..
-
-      At worst, you’re frightening and even possibly hurting good people unnecessarily and charging them exorbitant fees couched in good will and trust.. That my friend makes you a sham artist and a snake oil salesman, whether you admit it to yourself or not.. You can get mad at me all you want but you have yet to prove me wrong or to say anything that would make me think otherwise..
-
-      All you’re doing is making my point for me..
-
-      Thanks.
-
-
-Dr. Calvin, (Not a doctor) - October 24th, 2009 at 10:21 PM
-
-      Dr. Dalton RN, DC wrote:
-      “Do you really think that the government or insurance companies would pay for witchcraft.”
-
-      Short answer…yes.
-      “One of the most fascinating recipients of tax money from the Institute is the United Religions Initiative (URI), dedicated to creating a global religion. It got $30,000.
-
-      One of the religious traditions considered legitimate by the URI is Wicca or witchcraft.”
-      Source: http://www.aim.org/media-monitor/government-funded-investigative-reporting/
-
-      Dr. Dalton RN, DC also wrote:
-      You do not have to be a medical doctor to be considered a “real doctor”.
-
-      Quite true. Last I checked they were offering doctoral degrees in all sorts of stuff. Those people get to be called doctor too.
-
-      Chiropractors just prove that you can get people to call you “doctor” while only having a 4 year degree.
-
-
-Ann - December 14th, 2009 at 2:52 PM
-
-      Your story sounds exactly like mine. The reality is that I had several fractured ribs due to osteoporsis, but the chiro insisted I had subluxation. He did more harm to me and I’m lucky I dropped him and learned what was really wrong with me before this clown hurt me more.
-
-      It’s no wonder that the fractures did not show up on his x-ray – the machine was so old that I’m sure it was inadequate. The fractures did show up on my primary care’s lab x-rays though. And he also tried to tell me that my neck and spine were too curved too, that I was on the verge of the “s” spine.
-
-      I never returned after I realized I’d been scammed. And I know others who have had the exact same office visits and treatments.
-
-      He got my insurance payment, but I never paid him $500 he billed me, and I told the attorney (geez, go figure) who recommended him to me that I was not going to pay it and I would sue him for malpractice if he tried to collect it from me. I never heard from them again.
-
-
-<i class='icon-star'></i> Jason - December 15th, 2009 at 1:34 PM
-
-      Wow Ann.. I hope you have no lasting pain or damage.. that’s just awful.. and yet an all too common story.. You likely wouldn’t believe the number of people that write me that have similar tales..
-
-
-Alton - January 5th, 2010 at 8:00 AM
-
-      O Jason, the chiro stories just go on and on.
-      So many of them tie themselves to some unheard of religion and walk around in their “exam cubicles” like they are saints or something, all the while hopeing that you will surrended BIG bucks to the receptionist when you depart their laire.
-      Check out this link http://www.allstressedup.com and be glad you were spared from these shaynanigans.
-      My dad went to this one and dropped over $1000 for 2 “treetments”.
-      Don’t forget to check http://www.ratemds.com when considering another doctor.
-
-
-Mitchell - January 30th, 2010 at 8:36 AM
-
-      There are two words to listen for here in Atlanta if seeking treatment – LIFE UNIVERSITY. If you ever hear that a Chiropractor has schooled there, RUN for the hills. Remember EST training, Tony Robbins? Their entire strategy is SALES.
-
-      Life University itself has one of the largest “drive through” Christmas light displays you will ever see for two months or so during the holidays. They have a huge campus in Marrietta Georgia, who do you suppose pays for all of this??? Their “leader” (think Manson or Koolaid) has that scary hard-purple-hair-preacher-on-TV look and is big on “continuing education”. Translation: paying the light bill at Christmas.
-
-      Ask any chiropractor is any state where they studied, if they say “Life” you will absolutely hear things like “Keep coming back”, “Turn on the power!”, I guarantee it. I know four “Life” chiropractors, two just casually that don’t know I’m aware of their cult and they all speak “Life” – test it.
-
-      I went to a Life chiropractor off and on for months in Marietta, GA and I think it was about 25-$30/visit – after all the show and dance, and x-rays from a machine out of a dumpster as noted above. The treatment was fine except the use of the “Spine-o-Lator” (no shit) that he always made my lay on after I was adjusted and rolled up & down my spine for 5 minute and was $15 extra.
-
-      I was then in a car accident, hit from behind and rolled over by a FedEx truck. I didn’t know what to do as I was not visibly hurt in any way, but was a bit dizzy, I did not go (refused) in an ambulance for care. I called my chiropractor and he said to get to the hospital for x-rays. I did so the next day and they basically kicked me out and said nothing was broken, but that’s about it.
-
-      Then I went to my chiropractor. I had been paying cash per-visit. He knew I had Blue Cross insurance, but if they file insurance they get paid less so I was a cash customer …. until this accident. Let me insert here this was my former, dyed in the wool “Life University – turn on the Power” Chiro. In fact, his office was so close I’m sure he picked up some sort of UFO signal from the hard-haired leader.
-
-      Does anyone see where this is going?
-
-      As soon as I went to see him after being x-rayed (which I did not carry to him), I went into the “exam” room with him and saw him remove my current chart that contained all my prior visits and grab a FRESH one. I’m not one to be meek and don’t give anyone any slack and asked what he was doing. He said we had to start over as it was going to be an insurance claim. I never saw my old chart again.
-
-      So let me speed this up as I’m tired of it as well. I did the initial treatment, he started a new chart and said it would take about 30 visits. He THEN told me, “I know a personal injury lawyer around the corner” … I know, sounds like a story but it’s true. So I hook up with the lawyer as FedEx would not own up to the vehicle damage and FedEx turned a third-party-Nazi business against me to not pay for my auto claim (Crawford).
-
-      My $30 rate, went to $90 to the insurance company (PLUS the Spine-o-Lator rate). I was FORCED to do ALL of the treatments, otherwise the “Lawyer” could not substantiate the personal injury claim. The lawyer settled with FedEx flat (I got maybe $300 for “pain and suffering/Diminished Value on the vehicle”) and after 12 miserable months it was done.
-
-      Yes Peter Pan, these stories do come true.
-
-      Listen, I have had chiropractic treatment off and on for 25+ years since I was very young. I’m very active, then have to sit behind a computer. I remodel homes as an investor myself, do HARD labor and get hurt. There have been many times when I have been in blinding pain and tried everything in the world to help to NOT have to go to the chiropractor, but once I did, a good chiropractor can give you relief. Is it “permanent”? No. Does it seem they fix it one time and break it the next sometimes? Yes. Will I visit one again? Yes.
-
-      Here’s the deal. NEVER let anyone professing to be ANY kind of advisor/medical/healer press you into anything you don’t want to do. USE YOUR INTUITION. If you feel uncomfortable LEAVE. If they treat you improperly, DON’T RETURN.
-
-      It’s easy to bash a person, practice or any segregation when you’ve been slighted. If you are in sever pain are at the end of options, chiropractic is always an option
-
-      If they are from “Life”, run. Otherwise should you seek treatment, get x-rays from a MEDICAL doctor (and keep them, they are yours) and if a chiropractor insists on “taking their own”, LEAVE.
-
-      If you believe in and start any form of treatment, just do what I do and with every visit, consider these people PERMANENTLY ON PROBATION!
-
-      Be well – Namaste’
-
-      To support my “LIFE” theory, look at this article, especially “Patient Education and Practice Building” http://www.chirobase.org/01General/risk.html
-
-
-Rando - February 11th, 2010 at 11:21 PM
-
-      lol
-
-      I just went to see one because I hurt my back at work. The first thing I had to do was watch a video that reminded me of the Darhma videos from LOST, there was a guy behind a big ol’ desk telling me how “special” I am because my doctor chose to have this machine and that I’m one of the lucky ones, they even had kids on there saying how good they feel. Do kids really need a chiropractor?
-
-      I swear I was joining a cult of some sort. On day 2 I noticed they have a bookshelf of books with a spirituality section, don’t get me wrong I’m a believer of eastern philosophies/religions as well as some new age views but still I found it just weird. I’m starting to think that the colour chart and the spine x-ray was just a ploy to get info on where they should insert the alien probe and make me one of them.
-
-      Another thing I noticed is that no one leaves after there treatment, by the time I was done there were a few families sitting around sharing jelly beans. wtf?
-
-      Anyways they sent me off with a “self help” CD that sounds like an infomercial and a 3 third booking. All while my company is waiting for a response from the “doctor” on how my back is. I guess I’ll tell them I won’t know until I earn my tin foil hat!!
-
-
-dr. bobby mozafari, dc - June 16th, 2010 at 10:38 AM
-
-      sorry you went through such a bad experience. i don’t blame you for having a negative view of chiropractors… especially when you live in texas.
-
-      many chiropractors out there ruin the progress of the profession (and, believe me, it’s progressing greatly). it’s unfortunate that there are still those chiropractors out in practice. they shun all things medical and don’t care enough about professionalism, the way real doctors should.
-
-      just as it’s been mentioned before, there are bad people in every field. obviously, you know this. however, something i tell everyone is to do their research when looking for a chiropractor in their area. not only should they ask around (friends, family, medical doctors, etc), but they should also be made aware of things to look for or look out for when finding a good chiropractor.
-
-      first off, credentials are important. also, see what school they graduated from. the best schools, in my opinion, are logan university, new york chiropractic college, and national college of chiropractic. also, you want to look for a place that doesn’t only offer chiropractic adjustments, but therapy exercises, therapy modalities, perhaps a physical therapist on staff, etc. typically, those chiropractors think more progressively and care more about getting their patients well than swindling their patients. lastly, you want to find someone relatively young and someone you feel you can trust… someone who genuinely cares.
-
-      there’s a dichotomy in chiropractic where on one side, you have chiropractors who are more medically minded and on the other side, you have chiropractors who believe everything’s curable with supplements and chiropractic adjustments. most chiropractors that are graduating today lean more towards the medical side. the “dinosaurs” of chiropractic thinking tend to stay over to the anti-medical side.
-
-      keep in mind that chiropractic is still a relatively new healthcare field and is still evolving. also, it’s got a history of being dragged through the mud by the american medical association for years and years in attempts to eliminate competition whenever the field refuses to join their umbrella (like the osteopathic field did). since the supreme court decision of wilk v ama, things have been going better between the medical-chiropractic relationship and they continue to get better as the years go on.
-
-      oh, one last thing… your brain’s great at making you think that something isn’t there. so, even though you might have something wrong with your neck that originally caused you pain, your thalamus kinda tells the part of the body that’s sending the pain signals to shut up… it’s kinda like tuning out a car alarm in the parking lot after hearing it for a few hours straight. just because you can’t feel it anymore, though, doesn’t mean the problem still can’t be there… for example, i’m sure your older male relatives don’t get their prostates checked because it’s a fun way to spend an afternoon. they do it because there might be something going on that they haven’t had symptoms of yet (whether it’s pain, bleeding, etc). understand what i mean?
-
-      anyways, i know what i just typed out may not change your point of view based on the ridiculous experience you had, but i hope it did, if not just by a little.
-
-
-Allen Botnick DC - September 7th, 2010 at 8:10 AM
-
-      In response to Dr. Mozafari’s comment that the reason for chiropractic’s poor quality is because it is evolving, I take issue with that. All of the evidence says the opposite. So far the only thing that has been happening is the co-opting of medical techniques like nutrition or athletic training which are grafted on to the core subluxation methods. The entire field is a scam built around the false believe that adjustment is a biomechanical cure for the spine and that it takes a long time to work. Adjustments do not do this. Research and science proves that adjustments do not change the spine with repeat treatment. All that ever happens is a short term neurological stimulation that can speed healing by relieving pain. So when a chiropractor tells you that they can fix biomechanical problems in your spine with adjustment run. Biomechanical problems nearly always involve destabilization which means ligaments are loose and need to be restored for permanent cure. Because chiropractors can’t give injections they can’t give prolotherapy to accomplish this. Even worse, they are so anti-medical that they don’t even want to be allowed to cure patients, it is simply more profitable to keep them sick. So never believe a DC when he tells you that chiropractic problems are the result of a few bad apples, aside from individual problems like sexual harrassment the major overutilization and quackery always starts at the top with the schools teaching it to the chiropractic students.
-
-
-<i class='icon-star'></i> Jason - September 9th, 2010 at 3:16 PM
-
-      Wow.. Good post Allen.
-
-
-Kelly - October 16th, 2010 at 5:45 AM
-
-      Chiropractic has helped me greatly. Allen Botnick it seems that you have a habit of making bad decisions. You didn’t investigate the school you decided to attend and then stayed there after you realized you made a bad choice. Heck you admitted that you graduated with honors but wasn’t smart enough to pass your boards the first time and couldn’t even get patients in the clinic. After you got burned working with the first chiropractor you should have just opened your own office but instead you made more bad decisions and joined forces with more and more chiropractors that turned out to be bad doctors. So Allen it seems that you are angry at the chiropractic profession because you failed as a chiropractor and now you want to put the entire profession down.
-
-      Some of my good friends are Chiropractors and they had to have 4 year undergraduate degrees before they even started the Chiropractic program. Total of 9 years of schooling so that’s why they are called doctors. Jason, while your bitching about chiropractors there are people that have great long lasting results, while your back pain has probably returned by now.
-
-
-Mark - October 19th, 2010 at 5:23 PM
-
-      Sorry to resurrect an old post, but here’s something interesting for you. http://skeptoid.com/episodes/4042
-
-
-<i class='icon-star'></i> Jason - October 20th, 2010 at 11:53 AM
-
-      @Kelly; Mm nope.. I’m good thanks.. Plus I don’t see where allen is saying all the things you say he’s saying.. Thanks for commenting though, your response did absolutely nothing to further the discussion.
-
-      @Mark; Nice.. Thanks! Let me sum up for folks who don’t want to read it;
-
-      [...] chiropractic was established and defined by a non-scientist during a time when almost nothing useful or true was known about medicine. In this case, our inventor was Daniel D. Palmer, a practitioner of New Age healing with magnets, when medicine was in the Dark Ages of 1895. Palmer believed that his magnets could manipulate a type of immaterial spiritual essence which he believed exists in the body, and which he called “innate intelligence.” [...]
-
-      Soooo… He was an entrepreneur who invented a phony medical procedure that could cure people for the low low price of … He was trying to make money on peoples fears and pain by offering a cure. A lot of phony/fake medical devices and scams were going on back then, this one just stuck.. Seriously.. Innate intelligence?!
-
-      [...] The cornerstone of chiropractic is something they call a subluxation. The first and most important thing to understand is that a chiropractic subluxation is a completely different phenomenon from an orthopedic subluxation, which is a real medical condition, and is unrelated. An orthopedic subluxation is a partial dislocation of a joint. They are significant physical displacements, and as such, they can and do appear on images such as X-rays, MRI’s, and CAT scans. A chiropractic subluxation, on the other hand, is theoretic and is not visible on an imaging study or otherwise verifiable through conventional medicine. [...]
-
-      So they decide to redefine a real medical term, to mean something else.. why would they need to do that if they weren’t full of shit?
-
-      [... ]The chiropractic profession has repeatedly redefined a subluxation over the years, and the current definition is “a complex of functional and/or structural and/or pathological articular changes that compromise neural integrity and may influence organ system function and general health.” As you can see, it’s quite a vague definition and leaves plenty of room for individual interpretation. In practice, it usually refers to an alleged misalignment of adjacent vertebrae.[...]
-
-      Not just redefining it, but constantly redefining it at that..
-
-      [...]According to the medical profession, such a misalignment would not have any of the detrimental effects on organs or general health claimed by chiropractors. Additionally, were there an actual nerve impingement in the spine, it would absolutely be visible on an imaging study and would absolutely not be treated through manipulation, which could easily result in irreparable injury.[...]
-
-      Exactly my point.. So they have to redefine what a subluxation is to not be what real medicine says it is, then treat it as if it were exact that.. Crock of shit..
-
-      [...]Chiropractic treats imaginary conditions, that could not possibly cause the reported symptoms even if they did exist, using methods that would be highly detrimental on an actual impingement.[...]
-
-      I disagree completely.. I think that chiropractic treats real conditions with imaginary cures.. Remember we are manipulating “innate intelligence” here..
-
-      Where that’s bad is if it’s a real condition, you can manipulate all the “innate intelligence” in the world and not fix the problem which most likely will only result in an exacerbation of the issues..
-
-
-Toni - October 23rd, 2010 at 12:58 PM
-
-      I dragged my husband to one of these promotional chiro deals because he had been sick and SUFFERING with allergies/sinuses for 9 months. He hadn’t slept for more than 2 hours at a time because he couldn’t breath. His back pain was EXCRUCIATING from frequent vomiting phlegm. I had spent hundreds of dollars on herbals with little relief (ginger tabs helped the digestion of the phlegm). As a result of personal experiences, he considers doctors and their drugs to be a money hungry system of quackery who do more harm than good.
-
-      We both went to see the promotional chiro because the price was $27 for one and $10 for each additional family member. We had the same experience as the author, and left without any change in our condition, though our wallet was a little lighter. As soon as we got to the car he told me this was a scam (he use to be a high-priced sales and marketing consultant) The only reason he didn’t confront this chiro about this scamming technique is because he had made a promise to me to be on his best behavior (he has a low BS threshold and often has confrontations with business dealings)!!
-
-      The next day we went to a chiropractor/acupuncturist whose paperwork consisted of “circle on the body diagram where you are experiencing problems”. He treated my husband, using both techniques, the whole process lasting about 30 minutes. That night my husband slept for over 9 hours and not once did he wake me up with really LOUD snoring. Hif face isn’t swollen and he can breath through his nose. His back feels better and though the chiropractor/acupuncturist never said he needed to return for more treatment, we definitely will.
-
-
-<i class='icon-star'></i> Jason - October 24th, 2010 at 4:25 PM
-
-      So.. You’re saying Chiropractic cured Sleep Apnea.. Bullshit. Your husband slept 9 hours because the night before he couldn’t sleep due to previous suffering.. More over, you’ve likely been tired too if he’s waking up as often as you imply, so the reason he didn’t wake you with loud snoring isn’t because he wasn’t snoring, but because you were tired and stayed asleep..
-
-      This is more than likely a coincidental “cure” that I’m sure they are more than happy to take credit for..
-
-
-Toni - October 26th, 2010 at 9:45 AM
-
-      I never said the chiropractic treatment cured his “sleep apnea”. But his sinuses are clear for the first time in 9 months and he has continued to sleep through the night since the treatment. During the past 9 months he has slept in 2 hour intervals because he had difficulty breathing. So I guess what I’m saying is clear sinuses has cured his “sleep apnea”. I doubt it was the chiropractic treatment that helped his sinuses as much as the acupuncture. My point was the “activator treatment” was obviously a scam. We became desperate for some relief for him which is why we went in the first place. He went to an acupuncturist/chiropractor 5 days ago and he has been able to breath and sleep ever since. We are very thankful for this treatment and hope he is on the road to recovery (he lost a lot of weight due to nausea from the sinus drainage). I wouldn’t have believed this would work either if I hadn’t seen it for myself.
-
-
-<i class='icon-star'></i> Jason - October 28th, 2010 at 11:44 AM
-
-      Okay so it sounds like you’re whole point is that Chiropractic didn’t and doesn’t work and that you think its a scam but Acupuncture does work.. Acupuncture which is also widely accepted as a scam..
-
-      I have no experience with acupuncture personally but I don’t understand how poking someone with a needle will clear their sinuses.. (unless you poke a large enough hole to allow drainage..) .. or anything for that matter..
-
-      Again, I’m skeptical at best.. Most likely any perceived effects of acupuncture are probably due to a combination of expectation, suggestion and other psychological mechanisms.. Aka Placebo.
-
-
-Jesse P. - November 14th, 2010 at 8:18 PM
-
-      This is a good debate although i will say from experience that the TRUE chiropractic doctors are those of “upper cervical spine doctors” Other known as Atlas Orthogonal specialists. They address the root of the problem. Your atlas, which is the very first vertebrae that aligns the rest of your spine. Trust me i have suffered with a misaligned atlas for many years my symptoms ranging from intense cranial pressure, dizziness, neck stiffness, pain, vision problems, weird feelings in my head, irritability, general malaise and a few more. Also like you, my body shifted. My leg was not shorter but my shoulders where no longer parallel. When she first examined me she told me to stand still and close my eyes. When she told me to open them again my head (not consciously being aware of) was tilted to the right. She then proceeded to tell me about my misaligned atlas. When i took the x-rays, it was 11 degrees off, a severe case. So what happened is, she used the machine similar to the one you explained, the awkward position isn’t all that bad, so after putting the orthogonal machine, jammed close to my ears she pulled the trigger and soon after i felt the blood rush through my head and felt a calm feeling and my cold clammy hands slowly went warm i felt the positive effect. When i came out of my first visit i didnt feel all that good… I felt out of place a little weird. Even trouble swallowing. The next week i had went again and it turned out a little bit better that time. And that was it for my atlas It had stayed put and this is after only 2 treatments with the orthogonal machine. So now, this is where the magic begins, on the third visit, she proceeded to adjust my c5 for the first time which is very different from the regular chiros, There is no cracking or harsh manipulations, thats what i love about it. So anyway when she had gently adjusted me using the table to shift down and let gravity do its work all while laying down on the table looking slightly down, my left shoulder instantly had a radiating pain shooting down my left arm. I got a little scared but she reassured me.. I didnt feel immediate effects but after a couple of times after one day i remember going in and getting adjusted And felt amazing like my whole world had a different meaning a depth of field that i didnt know of, the colors where bright and vivid. So fast forwarding, after about 10 treatments every week it was once a month the quickly went to once every 6 months! which is good news as my atlas has stayed in place for 9 months!
-
-      Now heres the thing they dont tell you about. Is HOW to further improve your neck and spine. After many years of research ive come to the conclusion that posture is ESSENTIAL and NUTRITION. Keeping good posture while sitting and standing is key, but really when it comes to the developing of your spine, proper sleeping position is whats going to affect your posture the most, yes. A good firm bed and… No pillow. Thats right, as humans we didnt evolve with a pillow attached to us, no animal on this planet uses pillows. It is absolutely unnatural to prop up your head at night especially if you sleep on your stomach and back. On the sides its O.K but we tend to move at night so its no good. Babies when born have no pillows in order to develop the spine, to keep it in its natural alignment. As the baby grows and later on given a pillow this is the biggest mistake. When the person reaches around the 20′s You can differentiate the ones who had used a pillow and the ones who dont. Now the next thing to heal the neck is nutrition, i mean, proper nutrition! (this is coming from someone who was a vegan and a vegetarian) I wont get to much in this as you can read a whole page on this here:http://www.biblelife.org/neck.htm (And no its not about religious beliefs)
-
-      Alright i hope after all of this you find your way in healing! Also dont forgot to check out more about primitive ways of sleeping and such. After 4 years of suffering and getting better again.
-
-      All the best
-      Jesse P.
-
-
-Jack - December 17th, 2010 at 1:20 PM
-
-      My prior chiropractor just told my friend that she should see a medical doctor because he thought she had a very bad kidney infection, which was true. Not all are bad and I have been to some snake-oil ones myself. Look for those who will take the time to TALK to you BEFORE asking for the $$$. Those are usually the ones who really care about their patients quality of life (no pun intented for Life University).
-
-      Oh, also, I had a computer repairman, who was recommenened to me by a computer programmer, who scammed me out of replacing my “motherboard” as the problem. So, look, listen, & ASK before going to any “professional”, especially the 15 minute to 1 hour oldest profession ones!!!
-
-
-Ibuzz - January 13th, 2011 at 5:26 PM
-
-      I went to a chiro in Southwest FL and it’s associated with Maximum Living – Dr. Loman. I felt like I was at a cattle feeding, in out in out came the families, little kids, wives, husbands, etc. I “won” a free consult, a $245 value, sat through the first and second visits, was told I’m in really bad shape and some of the crooked vertebra are linked to my thyroid and heart, so he’s really concerned. Tonight I was to go to another free meeting but I MUST bring my wife. We’ll sit in a room and watch a movie then go to a private room to see my X-rays then discuss treatment and money. I read one of these posts where they said they’ll throw out a high number then get you to agree to a huge discount but it’s still like $2500. I don’t know b/c I’m not going back. I have shoulder pain and could go for physical therapy as prescribed by my Orthopedic, but I wanted to try something else. Not now unless I literally go to a Chiro and ask if they treat me based on Subluxation. I believe some Chiro’s would treat the back and try and help the pain.
-
-      I’ve had an MRI on my shoulder and I have slight to moderate arthritic changes and tendentious. Can a Chiro help this or should I take the advise from the Orto and go to the Physical therapy?
-
-
-Chub - February 11th, 2011 at 2:24 PM
-
-      Jason, I am seeing a chiropractor in South Austin for a neck injury. I am not ready to pass judgement yet but I do wonder if my neck pain would resolve on its own without the chiro. I’ll break down what has happened so far…
-
-      First Visit: various balance tests and movements to see if my injury is muscle or disc related. No Xrays or MRIs. Chiro feels confident it is disc as bending over and coughing was extremely painful, that was 2 weeks ago. Now it doesn’t hurt to do that unless I really push it. Also did sensory tests all over my body (pricking me and asking me for points). After the tests we did ice and an activator adjustment with me sitting up and he behind me making me bend my neck in certain positions.
-
-      Following visits:
-      Either consist of ice and heat treatments with a roller table (I am lying on my back), in adddition to the alpha-stim machine attached to my skin. Also Physical therapy. I have done various balance exercises and neck exercises to strengthen the neck muscles he thinks let me get to where I injured my disc.
-
-      So to summarize I am still seeing him and will continue the PT exercises at the office and at home.
-
-      [Additional]
-      I forgot to mention each visit he does an adjustment, either manual or activator. I am skeptical of the activator but he claims it is stimulating my receptors to help my brain rewire and stimulate the muscles there. (very chiropractor like talk) This is in addition to the PT. Each visit is about 40 minutes – 1 hour.
-
-
-<i class='icon-star'></i> Jason - February 11th, 2011 at 4:06 PM
-
-      Out of curiosity, was your chiropractor a “nice guy”.. in kind of a slimy used car salesman way? It seems a trend..
-
-      Either way, just to be clear.. You went to a Chiropractor with neck pain.
-
-      He then performed the shenanigan dance that is the chiropractic equivalent to triage and determined that you were a prime sucker..er I mean that you had an injured disc in your spine.. And he then started poking and prodding that area as well as applying ice/heat..
-
-      Wow.. where to begin;
-
-      Firstly, what type of Spinal Disc issue is he trying to say this is? Herniation? Protrusion? Bulge? Tear? Your “doctor” made a diagnosis of “hurt disc” which lets be honest here, is no diagnosis at all..
-
-      More over he made such a diagnosis without any x-rays and by making you do a balance test? really? So.. he put a scale under each foot and “proved” to you that you had a spinal issue because your weight didn’t span both scales 50/50? All that test proves is that you aren’t synchronous creature.. Shocker.. It’s almost like some of your organs internally aren’t perfectly aligned or are to one side or another of your body..
-
-      Seriously, If you actually had a serious disc issue the last thing you would have wanted was for some jack wagon to be poking you with a hammer..
-
-      If it truly was an injured disc, what exact was heat/ice supposed to do other than just make it feel a little better? Couldn’t you have done that yourself? All he has sold you is good feelings and he is taking credit for what nature was going to do all by itself.
-
-      The majority of herniated discs heal themselves in about six weeks and don’t require any form of surgery. Of course, Some do require surgery, but you wouldn’t even be able to move if you had that kind of injury and likely would have gone to the hospital in an ambulance..
-
-      It’s more likely you had a muscular issue or a minor disc issue that would have resolved itself with time..
-
-      I think you need to be very realistic with yourself and ask your self some serious questions; So you had some pain and you wanted relief now, sure.. I completely understand.. But what did the chiro really do for you that an ice pack or a heating pad, some motrin and time wouldn’t have done?
-
-      Nothing.
-
-      Cogent Historical Paradigm: Hundreds of years ago in primitive tribes, if you got sick you went to the witch doctor for a cure.. He sat you down, danced around you, blew smoke at you and shook a chicken foot over your head.. If you got better, the witch doctor cured you!! Man those witch doctors were awesome!
-
-      How is it different? We can’t prove that the witch doctor didn’t cure the individual. Just like I can’t prove that the chiropractor didn’t cure you..
-
-      But isn’t it more likely that this is a case of a professional scam artist that has nothing better to offer society than selling “good feelings” is trying to to take credit for your own bodies natural healing process?
-
-      I hope you get better, I really do.
-
-
-Chub - February 12th, 2011 at 11:32 AM
-
-      Yes I am as skeptical about it as you are. I should re-explain the disc diagnosis.
-
-      disc diagnosis:
-      He said if it is a herniated disc only 5% need surgery and it will heal over time on its own. The only thing he did with the disc check was I sat on the table with my legs parallel with the ground. Then I bent my head/back downward towards the ground and stop when I feel pain. Then he had me cough to see how bad the pain was. All of this is a sign of a disc injury. He did not request x-rays or MRI.
-
-      Following tests:
-      We did some balance tests without any special equipment. No SAM machine or anything like that. If you google for the realage balance test it was like that. One foot up and eyes closed. Check each foot.
-
-      Another test was to check if my back goes flat when I lift my arms up while my back is close to and facing a wall.
-
-      The other tests were checking how tender my muscles were. He took this information and based the preceding physical therapy around it.
-
-      The heat/ice:
-      I was already taking 800mg of Ibuprofen very 6 hours with ice a few times per day. We did the ice for the first 1.5 weeks when I go; honestly I think he does it because he can and ice helps with inflammation. And yes nobody needs a doctor to do that. Last visit was heat.
-
-      I am taking all this as a skeptic and being objective as I can. As I think some of the chiropractors are new day Shamans, like homeopaths.
-
-      I think where I am benefiting is from the physical therapy and correcting how I do a lot of forward leaning all day at the computer. He is emphasizing to teach me ways to be more ergonomic so I can prevent any future injury. Along with doing the exercises at home which I can continue without paying them.
-
-      The still feel the activator adjustment is nonsense.
-
-
-Anna - February 27th, 2011 at 7:17 PM
-
-      I went to a chiropractor for the first time last week for a severe case of vertigo caused by an inner ear infection (viral labyrinthitis). The vertigo is not acute anymore in the sense that I can now walk and move my head without throwing up, but I still have dizziness, searing headaches, mental confusion, and a stiff neck. I read somewhere that adjusting the upper cervical spine can fix these problems, so off I went to a nearby chiropractor at a Wellness Center who had glowing reviews on Yelp. She had never heard of my condition and had to look through a medical textbook to find out what it even was. Then, after reading a bit, she said, “Well, it says here that antibiotics can sometimes help.” And I said, “Well, it wasn’t a bacterial infection, it was caused by a virus, so they didn’t give me antibiotics when I went to the ER.” Then she looked shocked and said “You mean you asked for antibiotics and they didn’t give them to you?” And I said, “No, they took a blood and urine sample, and determined that it wasn’t bacterial.” She then stared at me for a moment, and started to say, “You mean, they could tell by something in your blood…” then stopped, as she realized this made her sound like she knew nothing about medicine.
-
-      After having me stand in front of a mirror and move in certain ways, making various observations and comments, she had me lie face down on a table. She pressed on various points on my spine, asking me which of them felt “tender.” I didn’t understand what she meant, as everything on my back feels tender. So she pressed my hand, and said that I should feel no more than I felt when she pressed my hand. But the spine is where the nervous system is, I thought, so you’re always going to have more tenderness there than on your hand. But I tried to answer her as well as I could. As she went up my back to my neck I would answer more in the affirmative, that one disc or another was tender, and she rewarded me with, “Good, you’re getting the hang of it.” I thought her method of testing would be more scientific than this, for instance, an x-ray or computer imaging or something. But she merely wrote down my answers to what felt “tender,” some of which might have been arbitrary, and marked down which vertebrae they corresponded to.
-
-      The she held one arm up while tapping on my wrist. She also touched and brushed me on various parts of my body very lightly. She made verbal assertions as she did this: “You definitely have a virus…you live through other people- you need for others to be happy before you can be happy – this is a problem mostly in the workplace…” etc. Then she took a bottle of pills and held it against my stomach, all the while holding and tapping my wrist. “No, you don’t need these…” Another bottle of pills: “Three times a day.” Yet another: “Three times a day.” After that she used that activator machine and clicked on my face near my sinuses, which actually hurt quite a bit, then did some adjustments. She pulled both my ears out until they made sickening popping sounds: “It shouldn’t make a sound like that. It means you have a kink in your Eustachean tube. Now it’s straightened out.” (I later looked it up and I could find nothing in medical literature whatsoever about the existence of kinks in the Eustachean tube). Then she cracked my neck one way, and then the other. (OUCH)! Afterwards she said, “Well, we’ve done a lot today, doing any more would be too much for you. We adjusted your neck and your ears, we cleared viruses…” I was astonished. “You mean, you were able to clear viruses just by that tapping you were doing?” Her reply: “Well, basically, when you have a virus your body shuts down, so what I did was talked to your body and let it know the virus is there, so it can take care of it.” I said, as credulously as I could, “Oh, I see.”
-
-      Then she had me sit in a complimentary aqua detox foot bath, where you soak your feet in water in a machine for 30 minutes, or until the water turns black. The receptionist came in and said, “Oh, all that black is from smoking, or from living with second hand smoke.” I said “I don’t smoke and I’m never around second hand smoke.” She looked flustered and then said, “Well, then maybe it’s just pollution. And the orange is from your liver.” The “doctor” then wanted to know whether I would complete the full 6 session aqua detox at $50 a pop, and seemed cross when I said no, not right now. (The same foot detox machine she uses in her office can be bought on Amazon for $150, and 6 sessions in her office would have cost $300). The machine claims to detoxify your body, but has mostly been proven to be a scam. All it did was make my feet very clean.
-
-      While paying, the receptionist scheduled another visit for a few days later, and charged me for the two bottles of pills. I looked at one bottle – oregano capsules – and thought, what the heck, I know oregano is supposed to good for the immune system, so I’ll try it. But the other was for an antioxidant vitamin. I said to the receptionist, “I don’t know if I need these, I already take a vitamin supplement.” The chiropractor overheard me and said, “Well does your vitamin contain zinc? It’s well -documented that zinc helps with viruses.” I said “I don’t know.” She asked, “did you take your vitamin today?” I replied, “yes.” She rejoined sternly, “well, obviously you don’t get enough zinc, because your body tested for it.” I didn’t want to argue, so I bought the expensive little bottle of pills. Her voice had so much authority when she said that I tested for it. What was the test? That thing she did where she whooshed the bottle over my stomach and felt the vibes? (When I got home I saw that my multivitamin actually has more zinc than her supplement).
-
-      She scheduled me the next day for an acupuncture visit in the same office. When I ran into her in the waiting room, I asked her if she really thought my vertigo was related to my neck. She said, “Of course, it’s from years of injury from having bad posture.” (I had told her myself the day before that I thought I had neck damage from years of bad posture). She added, “That’s why you have a dowager’s hump.” After I finished my acupuncture treatment, which left a terrible black bruise under one eye, I went home and Googled “dowager’s hump,” and found that a dowager’s hump is an advanced state of osteoarthritis that leaves old women with hunchbacks. It is a real medical condition that can’t be reversed as there is so much bone loss, which never occurs in people of my age. It is however related to something called a “thoracic hump” which younger people do get, but which is a VISIBLE hump on the back from bad posture (there is no visible hump on my back).
-
-      I cancelled my next appointment with her after this, and will not be going back. Aside from the high cost of the first visit (the first visit is $165, whereas followup treatments are $55), my vertigo seems to have gotten considerably worse. I now have a new symptom, which is a fluttering inside my ear which sounds like a moth trying to get out. I looked up this symptom and it’s called tinnitus and is a result of vestibular damage. I’ve had my vertigo for two months now and never until now suffered tinnitus, which is a potential side effect of an inner ear infection and can lead to permanent deafness. I’m sure it was a result of damage that occurred when she pulled my ears. My neck pain is also worse, so bad that now I can’t sleep and sometimes actually cry out in pain just when turning my head on the pillow. Would subsequent visits fix all that? I don’t know, but after the careless way in which she pulled on my ears, having no idea whether it would damage them further or not, I’m afraid of her and don’t want to find out.
-
-      As a side note, I was not surprised by her shenanigans with passing the pills over my stomach, because two people I know had already told me stories about their chiropractors using this method to prescribe medications and treatment. It’s called “applied kinesiology,” and apparently a large number of chiropractors today use it. I wanted to add this story because no one yet had talked about this method, which more than anything else seems like a witch-doctor sort of practice.
-
-
-<i class='icon-star'></i> Jason - February 27th, 2011 at 7:38 PM
-
-      Holy crap! That’s a great story, and an awful one.. I seriously hope she didn’t hurt you..
-
-      I’d go see a doctor, and then a lawyer.. It’s quite possible she actually made you worse or at the very least did nothing but bilk you out of your hard earned cash all in the name of “curing you”..
-
-      It’s amazing to me.. How can these people live with themselves?
-
-
-Dr. Amy - April 2nd, 2011 at 20:23
-
-      First off, you must understand that there are good doctors and bad doctors in every field. This D.C. may not have had a good “bed-side manner” and was terrible about educating patients on what exactly they were doing. I’ll also admit that some of my colleagues have some strange methods, but that is why you do your homework and go to a doctor with good references just like you would a medical doctor. Chiropractic treatment is definitely more broad in it’s options where Allopathic medicine (seeing an M.D.) is more like symptom ABC gets prescription 123. Very cut and dry.
-
-      As far as education goes, Check this out:
-
-      [ Removing the link. I don't want to give these quacks the hits. ]
-
-      The school I went to covers Anatomy, Physiology, Chemistry, Diagnosis, X-ray and Orthopedics in WAY more detail than med schools. And Med schools cover Pathology, Ob/Gyn, and Psychiatry WAY more than Chiro school. The differences are to be expected due to the nature of our work.
-
-      As for safety of a Chiropractor, some may find it interesting to know that a Chiropractor’s malpractice insurance is OVER 5 TIMES LESS than any medical doctor’s (at minimum). Insurance premiums are directly related to risk (hence the reason our car insurance is so high due to my speed demon husband) so it can be assumed that seeing a Doctor of Chiropractic is over 5 times less risky than seeing a medical doctor. Just saying…
-
-
-<i class='icon-star'></i> Jason - April 4th, 2011 at 11:58
-
-      *sigh*
-
-      First off; You link a chiropractic website as proof that chiropractors are some how more educated and know more than real medical doctors. It’s propaganda, pure and simple. The website is owned by a chiropractor.. Hrmm.. More over, there aren’t any such MD websites that countermand this bold (and stupidly false) statement because they don’t need them.
-
-      Medical doctors not only know more, but do more for you and they have no need to prove it through propaganda or shenanigans.. Chiropractors do, and do so constantly because they know their image is shady as hell..
-
-      ( What makes it seem so shady? I dunno maybe everyone’s bad experiences with the profession or people with a 2 year degree coming along making bold statements about how much more they know than MD’s all while demanding to be called Doctor.. Just saying.. )
-
-      To say that the school you went to covers anything more thoroughly than a medical school is down right ludicrous.. What school is it? How long did you attend? What’s the normal course length to graduate as a DC there? What was your courses and specific field of study? How many hours did you study Chemistry? How many hours did you put into X-Ray.. etc.. Go on answer, lets put your claims to the test.. I call bullshit and doubt I’ll hear from you again on the matter.
-
-      As to malpractice insurance, your argument is sort of like saying it costs less to insure a Ford Escort than it does a Mercedes SLS therefore the Ford Escort is clearly better.. huh? Of course medical insurance is more expensive. Medical insurance has to be high because many of the procedures that they do can be invasive and risky.
-
-      That’s because medical doctors ACTUALLY DO SOMETHING!!
-
-      Name one thing that a chiropractor does that is as invasive as say; Surgery. Removing an appendix can be risky and can’t be fixed by chiropractic methods no matter what some douche bags say. (I found a link but I refuse to give him the hits.. just google it.)
-
-      So to that point, I will agree with you; Chiropractic exams and treatments aren’t very risky at all!! In fact I would say you’re at more risk driving to the chiropractors office, than actually being treated. But then thats because they don’t do anything. They massage you a little, maybe pay attention to you for a few minutes, poke you and prod you, and charge you for the good feelings and CO2 you just got.. They didn’t do anything other possibly enable the placebo effect.
-
-      The risky part with any chiropractic “treatment” is and always has been the notion that the “care” you just got is supposed to cure something that is really very wrong and that for which you should have sought real honest medical care.
-
-
-Dr. Amy - April 4th, 2011 at 22:32
-
-      If you want to, look up the prerequisite requirement and curriculum for UT Southwestern Medical School compared to Parker College of Chiropractic. My school was 3 years long, BUT we don’t get summer vacation like the med students who go for 4 years. I was on a different plan than the current students and had to finish in 9 trimesters vs 10 so I took an average of about 30 hours a semester plus all of my clinic hour requirements. As far as course of study, how many hours, etc., do the comparison yourself if you like. I don’t have time to itemize these for you and you seem to be quite passionate about your hatred for Chiropractic, so I have no doubt that you might actually do it. LOL
-
-      And you are totally missing the point of my argument about insurance. Medical doctors try to say that Chiropractic is dangerous, yet our malpractice insurance is significantly lower. My husband’s car insurance is significantly more expensive than mine because he has so many speeding tickets. He is more likely to wreck his car or hurt himself of someone else. He’s higher risk, hence the higher insurance. That was my point.
-
-      The are lots of people that have had awesome results from Chiropractic care. People who were told they needed surgery, avoided surgery and are now pain-free. People crippled by headaches are no longer getting headaches. On the other hand there are some that need medical care and are simply not going to get better with Chiropractic alone. I personally choose to use a medical doctor that practices homeopathy on the rare occasion that my family needs medical attention. He doesn’t give the mainstream drugs like all the rest of them do, he uses homeopathic remedies and diet to treat his patients but he’s effective just like myself and colleagues are effective especially with many musculoskeletal issues . Some D.C.s believe that Chiropractic can treat absolutely any issue. I’d have to say I disagree, but google something about Chiropractic helping and you will find millions of success stories whether or not you choose to believe it. If you don’t like Chiropractic, the solution is simple: don’t go see a Chiropractor! Hahaha!
-
-      “Real honest medical care,” HAHAHAHAHA!! If you are up for it, I got two videos for you. Food Matters and The Business of Being Born. We’ll see what you think about “real honest medical care” then, my angry friend! Happy blogging!
-
-
-<i class='icon-star'></i> Jason - April 4th, 2011 at 23:26
-
-      Lets look at the average MD and their schooling: It typically takes 4 years of undergraduate school to obtain your bachelor’s, followed by an additional 4 years of medical school and then several years of internship before you can even wear the title of MD. On average in the United States, it takes up to 12 years to reach the status of MD.
-
-      More over, all MD’s are required by their individual state to participate in ongoing education to make sure their skills stay sharp and that their knowledge is current. They are required to attend yearly classes, in-service training, and seminars. The simple fact of the matter is, as a MD you are never done with school.
-
-      Each state varies with the requirements and schooling, though not by a lot as I understand it.
-
-      So suddenly that 3 year degree isn’t all that impressive.. I don’t mean to take anything away from you as it sounds like you worked very hard to get the degree, but I question the value.
-
-      Either way, the above explains why your raw comparison of curriculum doesn’t even mean anything.. its apples vs oranges.
-
-      As to your allegation that MD’s are going around spreading vicious rumors about how dangerous chiropractic is, I’m not seeing it. Is there a danger, sure.. there is danger in anything.. but aside from the odd stroke warning there doesn’t seem to be a huge outcry from MDs defaming DCs or their practices.
-
-      Interesting that the opposite isn’t true.
-
-      As to Homeopathy.. OH dear god — Are you serious? Have you done any research what so ever as to what Homeopathy is and how it came about?
-
-      For a good chuckle, watch this video of James Randi explaining all about Homeopathy and then seriously do some research and reconsider.. He’s 100% truthful and honest.. http://www.youtube.com/watch?v=BWE1tH93G9U
-
-      Long story short: Samuel Hahnemann during the medical dark ages (a couple hundred years ago) called himself a doctor, prepared “medicine” of his own invention following his four absurd rules and sold it to people for profit.. He was a snake oil salesman.. Hrmm isn’t that exactly what Daniel Palmer did with his “innate intelligence”..
-
-      Ha! http://www.randi.org/encyclopedia/chiropractic.html
-
-      Thank you James.
-
-
-Dr. Amy - April 5th, 2011 at 13:02
-
-      Most medical schools do NOT require a bachelor’s degree up front. They require specific prerequisite classes which are identical to the ones required for Chiro school so most D.C.s have a prior bachelor’s degree but a few don’t just like med students. D.C.s also have to do several hours a year in continuing education so that their “skills stay sharp and that their knowledge is current.” As I mentioned before, the three years is without summer breaks so it’s about equal in the time spent in class and if you decide to go on to a more specialized practice such as radiology, you can go to school for an additional 5 years and become a Chiropractic Radiologist (DACBR) or get you could choose to get a diplomate in Neurology, Pediatrics, Sports Practioner, Functional medicine, etc, etc which most do specialize in one way or another depending on their interests requiring hours and hours of additional study. So your argument about education just doesn’t hold up.
-
-      Allegations of MDs against DCs is a huge deal whether or not you are “seeing it.” LOL There are blogs, papers, hell, even pamphlets and even billboards that M.D.s have posted about the “dangers of Chiropractic” that make people fearful of us, but that’s really not important to our current argument.
-
-      I have a couple of thing for you to think about.
-      1. I use a radiology center to do all of my x-ray/MRI because I choose not to invest in the equipment when I can use theirs down the street. When I send a patient there I get a report from an M.D. radiologist as well as a Chiropractic radiologist. The M.D.s report is usually about a paragraph and the D.C.s is about a page or more. A patient came in because he has shoulder pain radiating from his neck and numbness in his tongue. I sent him for xray and the D.C.s report described in great detail the surgery, knew that the surgery was to correct a Chiari malformation and suggested the patient return for MRI bc with that surgery and considering the symptoms he was having, he was concerned because some patients develop a cavity in their spinal cord after this particular issue which can put them in a wheelchair as a paraplegic within a few years. The M.D. didn’t so much as mention the “hardware” still left from the surgery he had on his skull and 1st vertebrae. Now tell me who the “quack” is in this situation? This Chiropractor quite literally saved this guy’s life as he knows it because if we had just had the M.D.s report this could have turned into a reversible situation but he can now get it taken care of.
-
-      2. I was actually supposed to be an entering freshman at UT Southwestern medical school and even had all of my financial aid approved and ready to go until I had a run-in with a neurologist that completely changed my thinking. I had dizzy spells and headaches and after a CT, MRI, and MRA with this neurologist, I was told that I “just have migraines” like my mother and that I needed to take 2 different kinds of medications with extensive lists of side effects in order to control them. I disagreed as I had done my own research and suggested the possibility of something called cerebral pseudotumor which the doc disagreed over and over again. I tore up the prescriptions and went to my Chiropractor. He went over the radiology reports from the 3 scans I’d had and pointed out that even the radiologist had listed several things that were “congruent with cerebral pseudotumor and needed to be followed up clinically.” The neurologist didn’t even see this statement because he didn’t even LOOK at my reports. The Chiropractor made some suggestions to help my problem naturally and, guess what? It worked!!! I decided that I didn’t even want to have access to medicine because I wanted to challenge myself to treat everything as naturally as possible. I called up UTSW and told them to cancel my financial aid and called Parker college. Who’s the quack? I shouldn’t even have to ask…
-
-      The thing is there are “quacks” in all areas. There are crappy Chiropractors, crappy Dentists, crappy Physical therapists, and even some crappy Medical doctors. I could go on an on especially with stories from when I worked in the hospital, but I have a patient on his way for a follow-up who was scheduled for surgery to fuse C4-5-6 but cancelled because after 3 treatments Chiropractic has reduced his pain by about 75% and eliminated the numbness and tingling in his right arm. But that could not have been with my help, because I don’t do anything right??!! I am just some dumb Chiropractor with a sub-par education! LOL
-
-      As for homeopathy, if you don’t like it and don’t believe in it, just like Chiropractic, don’t go! LOL A little colloidal silver and one homeopathic remedy and my daughter’s bilateral eye infection was gone in less than 24 hours. I’m in! Medical doctor would have given us an antibiotic which also would have worked but I prefer not to use those unless absolutely necessary because those are abused so much that their effectiveness is going down the toilet slowly but surely hence the danger of MRSA in hospitals. But to each is own. If you like popping pills from your M.D., then by all means, do it!
-
-      I have really enjoyed our little argument run we’ve had. I don’t remember how I can across your blog. I wasn’t looking for anything like this, just came upon it by accident. The funny thing is that as much as you are trying to discredit me and my profession, it’s actually making me stronger because if someone puts me on the spot with an argument similar to any of yours I can recall things that I said to you quickly as it’s fresh in my brain and debunk their arguments very effectively. LOL Maybe I’ll just crash more blogs if I find any similar or create one of my own. Haha!
-
-      Happy blogging, Jason!
-
-
-<i class='icon-star'></i> Jason - April 5th, 2011 at 15:26
-
-      After doing some more research it seems you’re right about the bachelors degree and medical schools. I will concede the point that in order to be a MD you don’t need to have a BA. I was misinformed. However, you have yet to prove to me at all anywhere that DC’s are some how more educated than an MD which seemed to be your point above.
-
-      More over, no where did I call you a “dumb chiropractor with a sub-par education”. If you choose to be offended then that’s on you. The fact of the matter is you’re likely more educated than I am. What I post here are my observations and opinions and as such they are my own, yet it’s interesting how many other people out there with absolutely no ulterior motive is also “trying to discredit you and your profession”. If I were a MD and bashing DC’s then you could easily dismiss anything I said as professional rivalry, but that isn’t the case.
-
-      As to the danger of chiropractic procedures, my previous statements stands and no one has been able to counter it; those chiropractors that use “strange methods” to use your words and sell only good feelings, some attention and CO2 are a danger to their patients because they are using big scary words and funky devices to convince good people that they need some unnecessary procedure. The “doctors” then charge exorbitant fees for said treatment over the course of sometimes months all the while couching those proceedings in good will and trust. That makes them sham artists and those kinds of shenanigans DO go on whether you practice them or not.
-
-      They are a danger to their customers because those individuals feel that they have gone to an expert who has their individual issue in hand and it’s being treated. When instead all they are doing is being taken advantage of and their medical needs are going unmet potentially worsening their condition. If you don’t do this then bully for you, but you’re clearly the minority. You have only to read the comments on this post to see all of the other folks who have had shady dealings with people in your profession. Or google it.
-
-      I’m sure chiropractic procedures have come a long way in the last hundred years, but the truth of the matter is they would have to considering chiropractic treatments were developed and defined by an inventor (Daniel D. Palmer) who was a new age healer who swore by the healing power of magnets and his ability to manipulate the immaterial spiritual essence that courses through our nervous system called “Innate intelligence”. Do you preach this to your customers? Do you wave magnets over people and tell them they are cured? Probably not, but there are those that do.
-
-      Ask yourself this; why would chiropractors need to redefine an orthopedic term to mean something else completely unless there was a plan to use it to bewilder and scare?
-
-      The cornerstone of modern chiropractic procedures and triage seems to be the subluxation. A bullshit term that they constantly define and redefine to be painfully vague, scary and completely unverifiable through any other means.
-
-      An orthopedic subluxation is a partial dislocation of a joint and as such is extremely bad and completely verifiable through image studies. A chiropractic subluxation is this theoretic problem that isn’t visible on any image study or remotely verifiable by any means other than apparently to make people stand on scales to check their weight or check to see if one leg is longer than another..etc.. Oh and to take the “doctors” word for it that you desperately need his help!
-
-      Its bullshit. It’s complete bullshit. You know it and I know it.
-
-      So, what about subluxations? How often have you told a customer that they have a subluxation? Because if you have ever said it, even once, you are a fraud. Period.
-
-      If you aren’t one of those DC’s then fine you’re one of the good ones.
-
-      “As for homeopathy, if you don’t like it and don’t believe in it, just like Chiropractic, don’t go.”
-
-      Here we go again, you have to “believe” in this treatment for it to work.
-
-      As I said above, that’s not medicine.. If I don’t believe in penicillin or Advil, it still works.. Yet for some reason for me to get any benefit out of your chiropractic treatments or homeopathy preparations I have to “believe”?
-
-      Requiring blind faith in some treatment for it to work is no different than what extreme religious faiths and cults do with their faith healing. It’s absolutely no different. Any and all perceived or actual benefits can be entirely explained by the placebo effect or the bodies own ability to heal itself with time. I just find it interesting how many homeopaths or chiropractors will be more than happy to take credit (and charge) for said results.
-
-      In my very first comment I stated; “I’m willing to concede that there are likely some chiropractors that aren’t complete fakes. But the methods they employ MUST be radically different than the ones I have seen so far.”
-
-      And that still holds true, but it’s apparent to me and those who seem to agree with me through this post and through countless others that the vast majority of the chiropractors out there are frauds with no more noble intent than to bilk the next sucker out of some money.
-
-      I am not a one man crusade out to crush a profession. There seems to be a rather large number of shady chiropractors out there as is evidenced by all the similar stories to mine, maybe instead of arguing with me you should urge those folks to fix their image and stop making your profession look bad..
-
-      I find it interesting that instead you seem to prefer trying to make me change my tune than to make them change theirs.
-
-
-Dr. Amy - April 5th, 2011 at 21:12
-
-      I never intended to prove that DCs are MORE educated, just that we are not LESS educated than MDs which was your argument all along.
-
-      As far as Chiropractors giving unnecessary treatments to patients I agree it definitely happens. Hell, I dropped my “mentor” because I believed he was over-treating, but you can argue that medical doctors have been known to do the same thing, a more specific example is when it comes to surgery. Orthopedic surgeons are in the business of doing surgery. That’s how they make their money. I’ve met tons of people who had surgery and still suffer from the issue they went under for. Some have had multiple surgeries for the same thing. Did they need the surgery? Maybe, maybe not. But they trust the doctor’s judgement regardless. I’ve also treated tons of people whom have been told they needed surgery, and through Chiropractic care, no longer suffer any pain or symptomatology and have not gone on for surgery. And I didn’t even use magnets or shake chicken bones or give them snake oil! LOL I’m not saying two wrongs make a right by any means, but simply pointing out that we must be cautious with who we trust with our healthcare. If someone wants to go to a Chiropractor or ANY doctor, I recommend they talk to friends and or family and choose one that suits them.
-
-      “Belive” was a BAD choice of wording on my part. I should have known you’d run with that. Haha! If there is a placebo effect in my office, it’s minimized by my methods which I believe to be similar to most of my colleagues. In my practice I take photographs of my patient’s posture before their first treatment and every few treatments and also take measurements of ranges of motion to get an unbiased, numerical reading of their progress just to name a couple of examples. This is allows me to show my patients whether (or not) we are helping. If we’ve reached a plateau in progress we change things up, add exercises, stretches etc. if they even need to continue care at all. Because I know about a thousand more Chiropractors than you do, I am confident to put you at east that you are incorrect in your assumption that a “vast majority” of Chiropractors practice the more outlandish techniques. My last trimester of school 2 students out of about 100 were reprimanded for treating patients with some of these methods you must be referring to. This is definitely not the norm and schools are taking steps to minimize this. I can only assume that your assumption is solely based on blogs and threads you’ve seen on the internet and it’s a fact that people whom have bad experiences are far more likely to speak up than people who had a good one. For instance, if you went to a restaurant and saw a rat or bug crawl across the kitchen floor, you might tell 5 people, but if you went to a restaurant that seemed completely clean you wouldn’t tell anyone because there was nothing of concern. That’s just human nature.
-
-      I’m sure you are correct in that lots of people have had “shady dealing” with DCs and you encouraged me to google that. Well, I encourage you to google the positive experiences too as well as “shady dealings” with other types of docs such as orthopedic surgeons. (I just searched the latter and found a TON of articles about unnecessary surgeries) And next time you lean over to pick something up and one of your paraspinal muscles spasms causing one of your lumbar vertebrae which it’s connected to to get yanked to one side sending horrible pain down the back your butt into the back of your leg due to a nerve impingement, go to your MD and get some muscle relaxers and a pain killer if you like and don’t mind the side effects of. My patients can continue to come to my office when this happens and I can give them immediate relief by fixing the problem at it’s source (the spinal fixation or “subluxation” as some of my colleagues call it) as well as teach them ways to prevent that from happening in the future. (By the way that ‘s’ work has created a huge divide amongst our profession and I personally prefer not to use it… shhhh!!)
-
-      As far as arguing with you, that’s just for sport  The truth is I like you Jason. You are a very good debater. I like to think I am too and I love a challenge so I am thoroughly enjoying myself and learning a ton from you about how some of the public may view my profession and how I can work to better it. I’ve also been brainstorming ideas for my website, newsletters and health talks, so I thank you for that!
-
+<section class="legacy-comments" aria-label="Legacy comments">
+  <h3 class="lc-heading">Legacy Comments</h3>
+  <p class="lc-note">Imported from the original thread. My replies are on the right.</p>
+  <div class="lc-thread">
+    <div class="lc-row me">
+      <div class="lc-meta"><span class="lc-name">Me</span> · January 25th, 2008 at 1:43 PM</div>
+      <div class="lc-bubble">
+        <p>Addendum; I’m willing to concede that there are likely some chiropractors that aren’t complete fakes. But the methods they employ MUST be radically different than the ones I have seen so far.</p>
+      </div>
+    </div>
+    <div class="lc-row them">
+      <div class="lc-meta"><span class="lc-name">Stephen Barrett, MD</span> · January 25th, 2008 at 2:35 PM</div>
+      <div class="lc-bubble">
+        <p>What happened to you is quite common. The leg-length/subluxation hoopla is part of “Activator Methods,” which we describe at <a href="http://www.chirobase.org/06DD/activator.html" target="_blank" rel="noopener">http://www.chirobase.org/06DD/activator.html</a></p>
+      </div>
+    </div>
+    <div class="lc-row them">
+      <div class="lc-meta"><span class="lc-name">Calvin</span> · January 25th, 2008 at 4:30 PM</div>
+      <div class="lc-bubble">
+        <p>“It really pisses me off that in the United States people can lie, and sell you snake oil and there is no law against it. It should be illegal. But the simple fact is, if someone plays on your fears or desires and bilks you out of money you’re just out that money.”</p>
+        <p>-Generally we refer to these people as politicians. I think we’re used to this type of treatment in the political arena and we’ve pretty much come to expect it. When this comes at us from the medical arena it sort of disturbs the sensibilities. I mean this isn’t the 19th century any more. But hey at least he didn’t sell you a bottle of heroin or prescribe trepanation.</p>
+      </div>
+    </div>
+    <div class="lc-row them">
+      <div class="lc-meta"><span class="lc-name">userandabuser</span> · March 5th, 2008 at 1:52 PM</div>
+      <div class="lc-bubble">
+        <p>my name is Nick, and my girlfriend is going through the same exact thing here in port st. lucie,fla. Just as you said “as soon as I entered the office my bullshit meter skyrockets and my spider sences are telling me to get out of there quick.” but my girlfriends parents are paying for the “treatments” so its my job to stay with my girl while he hits her with the clickie thing. so long story short, I’ve been to this office several times and it has very thin walls and one can hear into the next room quite well, and as far as I can tell everyone in this office has the same problem because everyone gets the same exact treatment. I got the one leg is shorter explination also and like you said my girls back still hurts after months of treatments and she has even developed new problems but hey one leg is shorter than the other right?</p>
+      </div>
+    </div>
+    <div class="lc-row me">
+      <div class="lc-meta"><span class="lc-name">Me</span> · March 5th, 2008 at 3:06 PM</div>
+      <div class="lc-bubble">
+        <p>Nick, get out while you can. The problem here is that the illusion of care that this “doctor” is giving does nothing. And your girl friend could actually be hurt or in danger.</p>
+        <p>Take her to a real doctor before whatever the problem is, gets worse.</p>
+      </div>
+    </div>
+    <div class="lc-row them">
+      <div class="lc-meta"><span class="lc-name">~M~</span> · April 2nd, 2008 at 7:46 AM</div>
+      <div class="lc-bubble">
+        <p>Hi Jason! I have just recently falling into this same situation and have been deciding what my best move is. I am wondering did u ever see a MD? What did they do for you &amp; how is your neck feeling now? Thanks so much!! ~M~</p>
+      </div>
+    </div>
+    <div class="lc-row me">
+      <div class="lc-meta"><span class="lc-name">Me</span> · April 16th, 2008 at 9:20 PM</div>
+      <div class="lc-bubble">
+        <p>Well at this point, I’m doing fine.</p>
+        <p>Ultimately I let time do the healing.. which is all that would have happend had I let the “doctor” help me.</p>
+        <p>I eventually went and saw a real MD and she basicallys aid that this was one of those things that’d go away with time.</p>
+        <p>I hope you’re feeling better.. Good luck.</p>
+      </div>
+    </div>
+    <div class="lc-row them">
+      <div class="lc-meta"><span class="lc-name">N</span> · April 21st, 2008 at 10:15 AM</div>
+      <div class="lc-bubble">
+        <p>That sucks you had such a negative experience. I go to a couple of Chiros down here in Aus and they’ve been great for my back treatment. They really address the pain and compared to the MDs who only give me drugs, they really know their shit at what they do to target the pain. They’ve been excellent by me and seem to care alot more than the doctors i’ve been to so I wouldn’t go as far as making broad generalisations about the entire practise. I’ve been to a doctor before who googled my symptoms onto the computer in front of me! I just swear by chiropractic, maybe you should just see a different one?</p>
+      </div>
+    </div>
+    <div class="lc-row me">
+      <div class="lc-meta"><span class="lc-name">Me</span> · April 22nd, 2008 at 10:25 PM</div>
+      <div class="lc-bubble">
+        <p>N, the issue I have is that other folks I have talked to feel the same way I do. Most think they are complete charlatans.</p>
+        <p>I mean I was trying to be open minded about them when I went to one, but my experiences to date haven’t been good.</p>
+        <p>If others find value in the service that they provide then so be it. I don’t know if your chiropractor is selling you good feelings or if he’s actually doing something to help you. (Or hell if selling you good feelings IS the something that helps you).. but for my part, they weren’t doing anything of any value to me.</p>
+        <p>I’d be hard pressed to go to another chiropractor at this point. I mean they aren’t cheap after all..</p>
+      </div>
+    </div>
+    <div class="lc-row them">
+      <div class="lc-meta"><span class="lc-name">Zoo Knudsen</span> · June 21st, 2008 at 6:38 PM</div>
+      <div class="lc-bubble">
+        <p>You should see what they do with kids, especially the anti-vaccination rhetoric they are so fond of. Oh, I’m sorry, the pro-information about vaccines rhetoric. Unfortunately their information is probably what Jenny McCarthy earned her Google Ph.D with. I enjoyed reading your post Jason. The sad thing is that you don’t even know how really bad things are in the world of chiropractic, but you’ve got a decent inkling.</p>
+        <p>What is the difference between a Doctor and a Chiropractor you ask? Doctors don’t call themselves chiropractors.</p>
+      </div>
+    </div>
+    <div class="lc-row me">
+      <div class="lc-meta"><span class="lc-name">Me</span> · June 22nd, 2008 at 11:41 AM</div>
+      <div class="lc-bubble">
+        <p>It really makes you wonder how this industry has lasted as long as it has..</p>
+      </div>
+    </div>
+    <div class="lc-row them">
+      <div class="lc-meta"><span class="lc-name">Shawn Lauriat</span> · June 22nd, 2008 at 12:24 PM</div>
+      <div class="lc-bubble">
+        <p>People believe in reincarnation, believe that their children will burn alive through all eternity unless they save them through rituals and punishment, and believe they can get healed over the telephone.</p>
+        <p>In contrast, chiropractors probably seem like educated doctors.</p>
+      </div>
+    </div>
+    <div class="lc-row them">
+      <div class="lc-meta"><span class="lc-name">Craig</span> · October 28th, 2008 at 1:04 PM</div>
+      <div class="lc-bubble">
+        <p>You have to realize that there are lying scumbags in every profession. There happens to be a lot in the chiropractic profession. However, there are also very good chiropractors who treat from a strictly evidence based musculoskeletal perspective using a combination of commonly accepted techniques (myofascial release, massage, traction, mobilization, adjustment, physiotherapy modalities and exercise prescription). Someone in this post said the quacks use the term ‘subluxation’ and this is essentially true. That’s the easiest way to differentiate a good chiropractor from a quack (obviously this is a rough guide). Anyways, I’ve had great relief from chiropractic treatment and nothing hokey was done to me or asked of me. I was asked about the pain and history of the injury, I underwent a full physical assessment and I was treated the same day and it only cost me $50 for the first visit and $25 for the next two visits that I needed. That’s it. You know that most professional sports franchises employ chiropractors to treat their athletes. Most amateur / olympic athletes see chiropractors. These are people that know their shit when it comes to health and fitness. The take home point is that there are bad apples everywhere and you have to be a smart consumer, even when it comes to health care. Do your research but keep an open mind.</p>
+      </div>
+    </div>
+    <div class="lc-row them">
+      <div class="lc-meta"><span class="lc-name">Andrea</span> · November 22nd, 2008 at 12:13 PM</div>
+      <div class="lc-bubble">
+        <p>OMG – It’s like you just wrote my story! These scam artist chiropractors must go to the same con school. I got the exact same spiel, right down to the Christopher Reeve story. I went in for HEADACHES (my con man ran an ad in the local paper for relief from headaches)and by the time I left his office he had convinced me I had arthritis in my neck and a dowagers hump! Oh and my right leg was 1 inch shorter than my left leg! I was basically told I needed immediate intensive treatment,which cost $10,000 but if I signed up for his plan today,he would reduce price to $4,000 and i could make payments. Of course i signed, he was very smooth con man, but as soon as I got home I realized i had been duped and I called his office and cancelled the contract, but not before he had charged me $350.00 for the first visit! People, please do your research when it comes to chiropractors, I’m sure there are some good ones, but from my research (after the fact)I have found that they typically run the same scam. Jason, Thank you so much for posting your story. I felt really stupid and embarrased after i fell for this, but reading your post has shown me that it wasn’t me, I am not stupid! These guys are running a scam and you are helping to expose it and helping “victims” of this chiropractic scam to see the light! Thank you!</p>
+      </div>
+    </div>
+    <div class="lc-row them">
+      <div class="lc-meta"><span class="lc-name">J. Patrick McCarver, D.C.</span> · December 21st, 2008 at 8:22 PM</div>
+      <div class="lc-bubble">
+        <p>Hello Jason, Sorry to hear about your experience at that chiropractor. The real problem in your story is two-fold: 1. The chiropractor never told you what was going on and what his role was in you getting better, and 2. you,being like most of us, wanting quick relief from whatever ails you. So if you would allow me a little of time I will try to explain what that other chiro was afraid to. Chiropractic doesn’t operate in the same field with tradition allopathic or alternative medicine. Both of these are concerned with treating your disease or symptom. Chiropractic is concerned with removing interference in your nervous system(NS). Chiropractic is not a “cure” for neck or back pain (or anything else for that matter). Your NS is the master control center for everything your body does. We only work with the back and neck because that is where your spinal cord is. I hate that you feel that all chiros are bad because of this guy, I mean I’ve been screwed over by a computer guy before, but that doesn’t that you are no good at what you do. Listen, it’s really simple, Subluxation is the term used to describe a vertebrae that is misaligned and causing interference to the NS. The job of the chiro is to remove the interference and allow the to function normally. I will readily admit that there are lots of shady chiros out there. If you ever go to one of us again, beware of anything that is mentioned beyond removing interferce to your NS. Back to comment about quick relief. Most of the problems we have with health is due to this problem. We don’t listen to our bodies anymore, we believe that every symptom is something to get rid of. Symptoms are typically your body’s way of telling you that something is wrong, that are not the problem. It would be like me replacing my moniter every time I got an error message on the screen. Health and healing take time, chiropractic helps the body do that better. I hope this helps in some way, if not I would be more than willing to talk to you personally, feel free to e-mail me.</p>
+      </div>
+    </div>
+    <div class="lc-row me">
+      <div class="lc-meta"><span class="lc-name">Me</span> · January 12th, 2009 at 10:01 AM</div>
+      <div class="lc-bubble">
+        <p>Thanks for your input Patrick I do appreciate it.</p>
+        <p>If chiropractic doesn’t operate in the same field with traditional allopathic or alternative medicine, then why do you call yourself a doctor? What form of medicine is it then? Is it medicine at all? More over, most D.C.’s actually go out of their way to show that their “cures” rival or even surpass any cure that you might find via modern medicine.</p>
+        <p>Your own marketing schemes and methodologies however makes your “science” smack of snake oil. Some sort of cure all that will solve all your ails if only you did this one thing, for the low low price of… over the course of months and months…</p>
+        <p>Chiropractic may concern itself with my nervous system, but I maintain that the activator method using that little thumper device can do absolutely nothing to adjust my spine, or to use your words, “remove interference in my nervous system”. Any comment to the opposite is pure shenanigans..</p>
+        <p>And while yes, “Subluxation” is technically a medical term its use in this manner is not only erroneous but misleading. A subluxation is a “partial dislocation”, and if someone has dislocated their spine then nothing you do will help. If you have a subluxation of the spine then the last thing you need is some jackass with a “hammer” fixing it. Used in the manner that it’s used by the chiropractic community, it’s designed not to educate but rather used as a term to scare and bewilder.. “Oh Noes, the ‘doctor’ is using a scary medical term that I don’t understand… I must need his help…”</p>
+        <p>You have been screwed over by one computer guy, but don’t blame all computer guys. Fair enough. Whats interesting is that there isn’t a larger belief that computer guys will screw you.. Yet when I tell my chiropractor story a lot of folks chime in with similar stories. So a lot of folks are getting screwed around by chiropractors.. No so much with computer guys huh..</p>
+        <p>So is that a failing in your industry that it attracts so many bad practitioners? Of the probably 100 people I have told this story to, a good 50% of them had a similar story and more knew of someone with a similar story.</p>
+        <p>You readily admit there are a lot of shady chiro’s out there.. that’s amusing because I don’t readily admit there are a lot of shady computer guys.. in fact I haven’t run across very many.. I’m sure they exist but they aren’t any where near as apparent as people of your profession.</p>
+        <p>Finally, I leave you with the same thing that I always find amusing.. Chiropractors always call themselves doctors. Doctors (of medicine) never call themselves chiropractors. I wonder why that is..</p>
+        <p>To use your words “Chiropractic is not a cure for neck or back pain, or anything else for that matter.” Excellent! I couldn’t have said it better.</p>
+      </div>
+    </div>
+    <div class="lc-row them">
+      <div class="lc-meta"><span class="lc-name">Brian</span> · January 12th, 2009 at 10:13 AM</div>
+      <div class="lc-bubble">
+        <p>Sorry for those that had a bad experience. I went to a chiropractor when I was 18 because I was getting migraines for my whole life. I saw all kinds of MD’s and neurologist who gave me drugs that didnt work. The chiropractor adusted me 8 times and I’ve never had a headache again. I recommend people to chiropractors a lot and most seem to have a very favorable experience. I’d keep searching for a good chiropractor. Good luck!</p>
+      </div>
+    </div>
+    <div class="lc-row me">
+      <div class="lc-meta"><span class="lc-name">Me</span> · January 12th, 2009 at 10:23 AM</div>
+      <div class="lc-bubble">
+        <p>See that’s the issue Brian, I think it’s pretty tough to find a “good chiropractor”. So far I’m pretty sure there is no such thing. My opinion, and the opinion of the majority of the folks I talk to is that they sell “good feelings” (placebo effect at best).</p>
+        <p>If “good feelings” works for you then so be it, but that sort of thing doesn’t help me. Snake oil sells and sells well.. The more they realize that, and the more honest folks are duped into buying into it … “your left leg is longer than the right.. oh noes!” … they more they will do it. People will continue to pay to cure things that don’t need to be cured.</p>
+        <p>It was said on the radio yesterday that a chiropractor is suing someone over his blog posts claiming defamation..</p>
+        <p>Being litigious about a profession that a lot of folks already see as a scam only makes it stink that much more.. it’s bad business simply because it’s bad PR furthering opinions like mine.</p>
+      </div>
+    </div>
+    <div class="lc-row them">
+      <div class="lc-meta"><span class="lc-name">Kelly</span> · February 12th, 2009 at 12:52 AM</div>
+      <div class="lc-bubble">
+        <p>I think it is sad that our health insurance companies help pay for these quaks to take advantage of people. I am sure that it makes everyone’s rates increase as a result. The whole profession should be illegal. It is nothing but a pseudoscience that reeks of fraud. People would heal just as well given enough time, but chiropractors like to take the credit for the body’s “innate ability to heal itself.” From my experience, chiropractic is ineffective at best and at worst it could potentially do harm.</p>
+      </div>
+    </div>
+    <div class="lc-row them">
+      <div class="lc-meta"><span class="lc-name">Chris Allen</span> · February 19th, 2009 at 9:47 PM</div>
+      <div class="lc-bubble">
+        <p>OMG.. thanks for your story. I laughed my ass off! I went for the first time yesterday and my bullshit meter was off the charts. I had to go back again today for the consult on the xrays. I wont’ be going back!</p>
+      </div>
+    </div>
+    <div class="lc-row them">
+      <div class="lc-meta"><span class="lc-name">Larry Mirous</span> · September 15th, 2009 at 12:40 PM</div>
+      <div class="lc-bubble">
+        <p>This story is so true, I just came back from the chiroprator, which I am a non-believer, but thought I give it a chance because of a lower sore back which I have had before because of marathon running and it has come at the worst time because the Chicago Marathon is only 4 weeks away. The same thing happen to me, $185.00 for x-rays and then the next vist the next day was to be $45 for an adjustment which I went to and then I was told come in every day for the next two weeks, I’m unemployed, it did not matter, and she also has people coming in watching videos on subluxation, the choice I made right then and there was to get the hell out of there while I still had money for groceries and my mortgage.</p>
+      </div>
+    </div>
+    <div class="lc-row them">
+      <div class="lc-meta"><span class="lc-name">al nixon</span> · September 29th, 2009 at 4:57 PM</div>
+      <div class="lc-bubble">
+        <p>Jason, Right choice, not going back. I went once, in 1968, and ended up having a stroke.</p>
+      </div>
+    </div>
+    <div class="lc-row me">
+      <div class="lc-meta"><span class="lc-name">Me</span> · September 29th, 2009 at 5:33 PM</div>
+      <div class="lc-bubble">
+        <p>OH god thats aweful..</p>
+      </div>
+    </div>
+    <div class="lc-row them">
+      <div class="lc-meta"><span class="lc-name">Dr. Dalton RN, DC</span> · October 24th, 2009 at 3:47 AM</div>
+      <div class="lc-bubble">
+        <p>Chiropractic has helped many people. Chiropractic has helped people that has had no luck with their medical treatments. Chiropractic is not for everyone. Have you ever heard of the “Mind and Body Connection?” Well, If you believe that you will never get well then you will not. If you believe that something bad will happen to you in life, then it probably will. And no, chiropractic is not medicine that’s why it is called Chiropractic. I’m sorry for those of you that have had a bad experience. I have had bad experiences with some of my past dentist, medical doctors, lawyers, etc. Instead of bad mouthing those professions, I went out and found what works for me. The doctor asked this person about falls as a child or abuse as a child because those childhood physical injuries can manifest 20 years later causing early degeneration of your spine. Chiropractic is not witch craft and one has to understand the anatomy and physiology of the body very well to understand the concept. Maybe the doctor did not do a good job of explaining. Your body needs time to adjust to the treatments provided. You can not expect for a few treatment to cure a problem that has been going on for 20 years. The patients that did not respond well to care in my office are usually the ones that missed several appointments and did not do the exercises or stretches as I asked. In my office, If I feel that I am unable to help a patient I will refer them to someone else and not waste anyone’s time or money.</p>
+        <p>Do you really think that the government or insurance companies would pay for witchcraft. No, they pay because chiropractic has helped many people and there is a need for this type of care. Everyone is not a good candidate for traditional surgery or medications. There is a time and place for every form of health care, you just have to find what works for you. Every single medication has side effects. Every surgery has risks. Studies have shown that the chances of strokes after cervical manipulation is very rare and about 1 per 1 million patients. There are many delicate chiropractic treatments and screening tests to rule out patients that may not be able to tolerate certain types of cervical manipulation. You do not have to be a medical doctor to be considered a “real doctor”.</p>
+        <p>I have worked in the Veterans hospital with people in tremendous pain and immobility and watched them decrease the use of their pain medications and become more mobile. These patients greatly appreciate or services so much that the military and veterans hospitals are expanding our services.</p>
+      </div>
+    </div>
+    <div class="lc-row me">
+      <div class="lc-meta"><span class="lc-name">Me</span> · October 24th, 2009 at 10:11 PM</div>
+      <div class="lc-bubble">
+        <p>You’re right in that you don’t have to be a medical doctor to be considered a real doctor.. I know someone who has their doctorate in computer science (I think its CS anyway).. He doesn’t insist we call him Doctor either, even though he certainly has the right.. He also went to something like 20 years of schooling to get that doctorate.. How much does the average DC go through? OH and one other important point, he isn’t trying to fool anyone into thinking that he is a medical doctor..</p>
+        <p>“If you believe that you will never get well then you will not. If you believe that something bad will happen to you in life, then it probably will.”</p>
+        <p>Again, you have to believe chiropractic methodology works, for it to work.. If you believe it doesn’t work, it wont work.. At best, that’s called the placebo effect.. You’re convincing them that you’re doing something to make them better.. You have to “believe” in chiropractic for it to work.. Sort of like a religion that uses “faith healing”.. its basically the same thing..</p>
+        <p>You sell good feelings.. You try to convince people that they are getting better by performing (in your words, not mine) witchcraft.. You use big words like “subluxation” and funking little devices over them, then charge them outrageous fees..</p>
+        <p>Were we a couple hundred years in the past you’d be shaking a chicken foot over their head..</p>
+        <p>And as I said above, THAT’S NOT MEDICINE.. If I don’t believe in penicillin or even Advil, it still works.. Yet I have to “believe” for your cure to work.. Hrmmm..</p>
+        <p>At best, you’re selling those people a placebo and the placebo effect is doing the work that you’re taking credit for..</p>
+        <p>At worst, you’re frightening and even possibly hurting good people unnecessarily and charging them exorbitant fees couched in good will and trust.. That my friend makes you a sham artist and a snake oil salesman, whether you admit it to yourself or not.. You can get mad at me all you want but you have yet to prove me wrong or to say anything that would make me think otherwise..</p>
+        <p>All you’re doing is making my point for me..</p>
+        <p>Thanks.</p>
+      </div>
+    </div>
+    <div class="lc-row them">
+      <div class="lc-meta"><span class="lc-name">Dr. Calvin, (Not a doctor)</span> · October 24th, 2009 at 10:21 PM</div>
+      <div class="lc-bubble">
+        <p>Dr. Dalton RN, DC wrote: “Do you really think that the government or insurance companies would pay for witchcraft.”</p>
+        <p>Short answer…yes. “One of the most fascinating recipients of tax money from the Institute is the United Religions Initiative (URI), dedicated to creating a global religion. It got $30,000.</p>
+        <p>One of the religious traditions considered legitimate by the URI is Wicca or witchcraft.” Source: <a href="http://www.aim.org/media-monitor/government-funded-investigative-reporting/" target="_blank" rel="noopener">http://www.aim.org/media-monitor/government-funded-investigative-reporting/</a></p>
+        <p>Dr. Dalton RN, DC also wrote: You do not have to be a medical doctor to be considered a “real doctor”.</p>
+        <p>Quite true. Last I checked they were offering doctoral degrees in all sorts of stuff. Those people get to be called doctor too.</p>
+        <p>Chiropractors just prove that you can get people to call you “doctor” while only having a 4 year degree.</p>
+      </div>
+    </div>
+    <div class="lc-row them">
+      <div class="lc-meta"><span class="lc-name">Ann</span> · December 14th, 2009 at 2:52 PM</div>
+      <div class="lc-bubble">
+        <p>Your story sounds exactly like mine. The reality is that I had several fractured ribs due to osteoporsis, but the chiro insisted I had subluxation. He did more harm to me and I’m lucky I dropped him and learned what was really wrong with me before this clown hurt me more.</p>
+        <p>It’s no wonder that the fractures did not show up on his x-ray – the machine was so old that I’m sure it was inadequate. The fractures did show up on my primary care’s lab x-rays though. And he also tried to tell me that my neck and spine were too curved too, that I was on the verge of the “s” spine.</p>
+        <p>I never returned after I realized I’d been scammed. And I know others who have had the exact same office visits and treatments.</p>
+        <p>He got my insurance payment, but I never paid him $500 he billed me, and I told the attorney (geez, go figure) who recommended him to me that I was not going to pay it and I would sue him for malpractice if he tried to collect it from me. I never heard from them again.</p>
+      </div>
+    </div>
+    <div class="lc-row me">
+      <div class="lc-meta"><span class="lc-name">Me</span> · December 15th, 2009 at 1:34 PM</div>
+      <div class="lc-bubble">
+        <p>Wow Ann.. I hope you have no lasting pain or damage.. that’s just awful.. and yet an all too common story.. You likely wouldn’t believe the number of people that write me that have similar tales..</p>
+      </div>
+    </div>
+    <div class="lc-row them">
+      <div class="lc-meta"><span class="lc-name">Alton</span> · January 5th, 2010 at 8:00 AM</div>
+      <div class="lc-bubble">
+        <p>O Jason, the chiro stories just go on and on. So many of them tie themselves to some unheard of religion and walk around in their “exam cubicles” like they are saints or something, all the while hopeing that you will surrended BIG bucks to the receptionist when you depart their laire. Check out this link <a href="http://www.allstressedup.com" target="_blank" rel="noopener">http://www.allstressedup.com</a> and be glad you were spared from these shaynanigans. My dad went to this one and dropped over $1000 for 2 “treetments”. Don’t forget to check <a href="http://www.ratemds.com" target="_blank" rel="noopener">http://www.ratemds.com</a> when considering another doctor.</p>
+      </div>
+    </div>
+    <div class="lc-row them">
+      <div class="lc-meta"><span class="lc-name">Mitchell</span> · January 30th, 2010 at 8:36 AM</div>
+      <div class="lc-bubble">
+        <p>There are two words to listen for here in Atlanta if seeking treatment – LIFE UNIVERSITY. If you ever hear that a Chiropractor has schooled there, RUN for the hills. Remember EST training, Tony Robbins? Their entire strategy is SALES.</p>
+        <p>Life University itself has one of the largest “drive through” Christmas light displays you will ever see for two months or so during the holidays. They have a huge campus in Marrietta Georgia, who do you suppose pays for all of this??? Their “leader” (think Manson or Koolaid) has that scary hard-purple-hair-preacher-on-TV look and is big on “continuing education”. Translation: paying the light bill at Christmas.</p>
+        <p>Ask any chiropractor is any state where they studied, if they say “Life” you will absolutely hear things like “Keep coming back”, “Turn on the power!”, I guarantee it. I know four “Life” chiropractors, two just casually that don’t know I’m aware of their cult and they all speak “Life” – test it.</p>
+        <p>I went to a Life chiropractor off and on for months in Marietta, GA and I think it was about 25-$30/visit – after all the show and dance, and x-rays from a machine out of a dumpster as noted above. The treatment was fine except the use of the “Spine-o-Lator” (no shit) that he always made my lay on after I was adjusted and rolled up &amp; down my spine for 5 minute and was $15 extra.</p>
+        <p>I was then in a car accident, hit from behind and rolled over by a FedEx truck. I didn’t know what to do as I was not visibly hurt in any way, but was a bit dizzy, I did not go (refused) in an ambulance for care. I called my chiropractor and he said to get to the hospital for x-rays. I did so the next day and they basically kicked me out and said nothing was broken, but that’s about it.</p>
+        <p>Then I went to my chiropractor. I had been paying cash per-visit. He knew I had Blue Cross insurance, but if they file insurance they get paid less so I was a cash customer …. until this accident. Let me insert here this was my former, dyed in the wool “Life University – turn on the Power” Chiro. In fact, his office was so close I’m sure he picked up some sort of UFO signal from the hard-haired leader.</p>
+        <p>Does anyone see where this is going?</p>
+        <p>As soon as I went to see him after being x-rayed (which I did not carry to him), I went into the “exam” room with him and saw him remove my current chart that contained all my prior visits and grab a FRESH one. I’m not one to be meek and don’t give anyone any slack and asked what he was doing. He said we had to start over as it was going to be an insurance claim. I never saw my old chart again.</p>
+        <p>So let me speed this up as I’m tired of it as well. I did the initial treatment, he started a new chart and said it would take about 30 visits. He THEN told me, “I know a personal injury lawyer around the corner” … I know, sounds like a story but it’s true. So I hook up with the lawyer as FedEx would not own up to the vehicle damage and FedEx turned a third-party-Nazi business against me to not pay for my auto claim (Crawford).</p>
+        <p>My $30 rate, went to $90 to the insurance company (PLUS the Spine-o-Lator rate). I was FORCED to do ALL of the treatments, otherwise the “Lawyer” could not substantiate the personal injury claim. The lawyer settled with FedEx flat (I got maybe $300 for “pain and suffering/Diminished Value on the vehicle”) and after 12 miserable months it was done.</p>
+        <p>Yes Peter Pan, these stories do come true.</p>
+        <p>Listen, I have had chiropractic treatment off and on for 25+ years since I was very young. I’m very active, then have to sit behind a computer. I remodel homes as an investor myself, do HARD labor and get hurt. There have been many times when I have been in blinding pain and tried everything in the world to help to NOT have to go to the chiropractor, but once I did, a good chiropractor can give you relief. Is it “permanent”? No. Does it seem they fix it one time and break it the next sometimes? Yes. Will I visit one again? Yes.</p>
+        <p>Here’s the deal. NEVER let anyone professing to be ANY kind of advisor/medical/healer press you into anything you don’t want to do. USE YOUR INTUITION. If you feel uncomfortable LEAVE. If they treat you improperly, DON’T RETURN.</p>
+        <p>It’s easy to bash a person, practice or any segregation when you’ve been slighted. If you are in sever pain are at the end of options, chiropractic is always an option</p>
+        <p>If they are from “Life”, run. Otherwise should you seek treatment, get x-rays from a MEDICAL doctor (and keep them, they are yours) and if a chiropractor insists on “taking their own”, LEAVE.</p>
+        <p>If you believe in and start any form of treatment, just do what I do and with every visit, consider these people PERMANENTLY ON PROBATION!</p>
+        <p>Be well – Namaste’</p>
+        <p>To support my “LIFE” theory, look at this article, especially “Patient Education and Practice Building” <a href="http://www.chirobase.org/01General/risk.html" target="_blank" rel="noopener">http://www.chirobase.org/01General/risk.html</a></p>
+      </div>
+    </div>
+    <div class="lc-row them">
+      <div class="lc-meta"><span class="lc-name">Rando</span> · February 11th, 2010 at 11:21 PM</div>
+      <div class="lc-bubble">
+        <p>lol</p>
+        <p>I just went to see one because I hurt my back at work. The first thing I had to do was watch a video that reminded me of the Darhma videos from LOST, there was a guy behind a big ol’ desk telling me how “special” I am because my doctor chose to have this machine and that I’m one of the lucky ones, they even had kids on there saying how good they feel. Do kids really need a chiropractor?</p>
+        <p>I swear I was joining a cult of some sort. On day 2 I noticed they have a bookshelf of books with a spirituality section, don’t get me wrong I’m a believer of eastern philosophies/religions as well as some new age views but still I found it just weird. I’m starting to think that the colour chart and the spine x-ray was just a ploy to get info on where they should insert the alien probe and make me one of them.</p>
+        <p>Another thing I noticed is that no one leaves after there treatment, by the time I was done there were a few families sitting around sharing jelly beans. wtf?</p>
+        <p>Anyways they sent me off with a “self help” CD that sounds like an infomercial and a 3 third booking. All while my company is waiting for a response from the “doctor” on how my back is. I guess I’ll tell them I won’t know until I earn my tin foil hat!!</p>
+      </div>
+    </div>
+    <div class="lc-row them">
+      <div class="lc-meta"><span class="lc-name">dr. bobby mozafari, dc</span> · June 16th, 2010 at 10:38 AM</div>
+      <div class="lc-bubble">
+        <p>sorry you went through such a bad experience. i don’t blame you for having a negative view of chiropractors… especially when you live in texas.</p>
+        <p>many chiropractors out there ruin the progress of the profession (and, believe me, it’s progressing greatly). it’s unfortunate that there are still those chiropractors out in practice. they shun all things medical and don’t care enough about professionalism, the way real doctors should.</p>
+        <p>just as it’s been mentioned before, there are bad people in every field. obviously, you know this. however, something i tell everyone is to do their research when looking for a chiropractor in their area. not only should they ask around (friends, family, medical doctors, etc), but they should also be made aware of things to look for or look out for when finding a good chiropractor.</p>
+        <p>first off, credentials are important. also, see what school they graduated from. the best schools, in my opinion, are logan university, new york chiropractic college, and national college of chiropractic. also, you want to look for a place that doesn’t only offer chiropractic adjustments, but therapy exercises, therapy modalities, perhaps a physical therapist on staff, etc. typically, those chiropractors think more progressively and care more about getting their patients well than swindling their patients. lastly, you want to find someone relatively young and someone you feel you can trust… someone who genuinely cares.</p>
+        <p>there’s a dichotomy in chiropractic where on one side, you have chiropractors who are more medically minded and on the other side, you have chiropractors who believe everything’s curable with supplements and chiropractic adjustments. most chiropractors that are graduating today lean more towards the medical side. the “dinosaurs” of chiropractic thinking tend to stay over to the anti-medical side.</p>
+        <p>keep in mind that chiropractic is still a relatively new healthcare field and is still evolving. also, it’s got a history of being dragged through the mud by the american medical association for years and years in attempts to eliminate competition whenever the field refuses to join their umbrella (like the osteopathic field did). since the supreme court decision of wilk v ama, things have been going better between the medical-chiropractic relationship and they continue to get better as the years go on.</p>
+        <p>oh, one last thing… your brain’s great at making you think that something isn’t there. so, even though you might have something wrong with your neck that originally caused you pain, your thalamus kinda tells the part of the body that’s sending the pain signals to shut up… it’s kinda like tuning out a car alarm in the parking lot after hearing it for a few hours straight. just because you can’t feel it anymore, though, doesn’t mean the problem still can’t be there… for example, i’m sure your older male relatives don’t get their prostates checked because it’s a fun way to spend an afternoon. they do it because there might be something going on that they haven’t had symptoms of yet (whether it’s pain, bleeding, etc). understand what i mean?</p>
+        <p>anyways, i know what i just typed out may not change your point of view based on the ridiculous experience you had, but i hope it did, if not just by a little.</p>
+      </div>
+    </div>
+    <div class="lc-row them">
+      <div class="lc-meta"><span class="lc-name">Allen Botnick DC</span> · September 7th, 2010 at 8:10 AM</div>
+      <div class="lc-bubble">
+        <p>In response to Dr. Mozafari’s comment that the reason for chiropractic’s poor quality is because it is evolving, I take issue with that. All of the evidence says the opposite. So far the only thing that has been happening is the co-opting of medical techniques like nutrition or athletic training which are grafted on to the core subluxation methods. The entire field is a scam built around the false believe that adjustment is a biomechanical cure for the spine and that it takes a long time to work. Adjustments do not do this. Research and science proves that adjustments do not change the spine with repeat treatment. All that ever happens is a short term neurological stimulation that can speed healing by relieving pain. So when a chiropractor tells you that they can fix biomechanical problems in your spine with adjustment run. Biomechanical problems nearly always involve destabilization which means ligaments are loose and need to be restored for permanent cure. Because chiropractors can’t give injections they can’t give prolotherapy to accomplish this. Even worse, they are so anti-medical that they don’t even want to be allowed to cure patients, it is simply more profitable to keep them sick. So never believe a DC when he tells you that chiropractic problems are the result of a few bad apples, aside from individual problems like sexual harrassment the major overutilization and quackery always starts at the top with the schools teaching it to the chiropractic students.</p>
+      </div>
+    </div>
+    <div class="lc-row me">
+      <div class="lc-meta"><span class="lc-name">Me</span> · September 9th, 2010 at 3:16 PM</div>
+      <div class="lc-bubble">
+        <p>Wow.. Good post Allen.</p>
+      </div>
+    </div>
+    <div class="lc-row them">
+      <div class="lc-meta"><span class="lc-name">Kelly</span> · October 16th, 2010 at 5:45 AM</div>
+      <div class="lc-bubble">
+        <p>Chiropractic has helped me greatly. Allen Botnick it seems that you have a habit of making bad decisions. You didn’t investigate the school you decided to attend and then stayed there after you realized you made a bad choice. Heck you admitted that you graduated with honors but wasn’t smart enough to pass your boards the first time and couldn’t even get patients in the clinic. After you got burned working with the first chiropractor you should have just opened your own office but instead you made more bad decisions and joined forces with more and more chiropractors that turned out to be bad doctors. So Allen it seems that you are angry at the chiropractic profession because you failed as a chiropractor and now you want to put the entire profession down.</p>
+        <p>Some of my good friends are Chiropractors and they had to have 4 year undergraduate degrees before they even started the Chiropractic program. Total of 9 years of schooling so that’s why they are called doctors. Jason, while your bitching about chiropractors there are people that have great long lasting results, while your back pain has probably returned by now.</p>
+      </div>
+    </div>
+    <div class="lc-row them">
+      <div class="lc-meta"><span class="lc-name">Mark</span> · October 19th, 2010 at 5:23 PM</div>
+      <div class="lc-bubble">
+        <p>Sorry to resurrect an old post, but here’s something interesting for you. <a href="http://skeptoid.com/episodes/4042" target="_blank" rel="noopener">http://skeptoid.com/episodes/4042</a></p>
+      </div>
+    </div>
+    <div class="lc-row me">
+      <div class="lc-meta"><span class="lc-name">Me</span> · October 20th, 2010 at 11:53 AM</div>
+      <div class="lc-bubble">
+        <p>@Kelly; Mm nope.. I’m good thanks.. Plus I don’t see where allen is saying all the things you say he’s saying.. Thanks for commenting though, your response did absolutely nothing to further the discussion.</p>
+        <p>@Mark; Nice.. Thanks! Let me sum up for folks who don’t want to read it;</p>
+        <p>[...] chiropractic was established and defined by a non-scientist during a time when almost nothing useful or true was known about medicine. In this case, our inventor was Daniel D. Palmer, a practitioner of New Age healing with magnets, when medicine was in the Dark Ages of 1895. Palmer believed that his magnets could manipulate a type of immaterial spiritual essence which he believed exists in the body, and which he called “innate intelligence.” [...]</p>
+        <p>Soooo… He was an entrepreneur who invented a phony medical procedure that could cure people for the low low price of … He was trying to make money on peoples fears and pain by offering a cure. A lot of phony/fake medical devices and scams were going on back then, this one just stuck.. Seriously.. Innate intelligence?!</p>
+        <p>[...] The cornerstone of chiropractic is something they call a subluxation. The first and most important thing to understand is that a chiropractic subluxation is a completely different phenomenon from an orthopedic subluxation, which is a real medical condition, and is unrelated. An orthopedic subluxation is a partial dislocation of a joint. They are significant physical displacements, and as such, they can and do appear on images such as X-rays, MRI’s, and CAT scans. A chiropractic subluxation, on the other hand, is theoretic and is not visible on an imaging study or otherwise verifiable through conventional medicine. [...]</p>
+        <p>So they decide to redefine a real medical term, to mean something else.. why would they need to do that if they weren’t full of shit?</p>
+        <p>[... ]The chiropractic profession has repeatedly redefined a subluxation over the years, and the current definition is “a complex of functional and/or structural and/or pathological articular changes that compromise neural integrity and may influence organ system function and general health.” As you can see, it’s quite a vague definition and leaves plenty of room for individual interpretation. In practice, it usually refers to an alleged misalignment of adjacent vertebrae.[...]</p>
+        <p>Not just redefining it, but constantly redefining it at that..</p>
+        <p>[...]According to the medical profession, such a misalignment would not have any of the detrimental effects on organs or general health claimed by chiropractors. Additionally, were there an actual nerve impingement in the spine, it would absolutely be visible on an imaging study and would absolutely not be treated through manipulation, which could easily result in irreparable injury.[...]</p>
+        <p>Exactly my point.. So they have to redefine what a subluxation is to not be what real medicine says it is, then treat it as if it were exact that.. Crock of shit..</p>
+        <p>[...]Chiropractic treats imaginary conditions, that could not possibly cause the reported symptoms even if they did exist, using methods that would be highly detrimental on an actual impingement.[...]</p>
+        <p>I disagree completely.. I think that chiropractic treats real conditions with imaginary cures.. Remember we are manipulating “innate intelligence” here..</p>
+        <p>Where that’s bad is if it’s a real condition, you can manipulate all the “innate intelligence” in the world and not fix the problem which most likely will only result in an exacerbation of the issues..</p>
+      </div>
+    </div>
+    <div class="lc-row them">
+      <div class="lc-meta"><span class="lc-name">Toni</span> · October 23rd, 2010 at 12:58 PM</div>
+      <div class="lc-bubble">
+        <p>I dragged my husband to one of these promotional chiro deals because he had been sick and SUFFERING with allergies/sinuses for 9 months. He hadn’t slept for more than 2 hours at a time because he couldn’t breath. His back pain was EXCRUCIATING from frequent vomiting phlegm. I had spent hundreds of dollars on herbals with little relief (ginger tabs helped the digestion of the phlegm). As a result of personal experiences, he considers doctors and their drugs to be a money hungry system of quackery who do more harm than good.</p>
+        <p>We both went to see the promotional chiro because the price was $27 for one and $10 for each additional family member. We had the same experience as the author, and left without any change in our condition, though our wallet was a little lighter. As soon as we got to the car he told me this was a scam (he use to be a high-priced sales and marketing consultant) The only reason he didn’t confront this chiro about this scamming technique is because he had made a promise to me to be on his best behavior (he has a low BS threshold and often has confrontations with business dealings)!!</p>
+        <p>The next day we went to a chiropractor/acupuncturist whose paperwork consisted of “circle on the body diagram where you are experiencing problems”. He treated my husband, using both techniques, the whole process lasting about 30 minutes. That night my husband slept for over 9 hours and not once did he wake me up with really LOUD snoring. Hif face isn’t swollen and he can breath through his nose. His back feels better and though the chiropractor/acupuncturist never said he needed to return for more treatment, we definitely will.</p>
+      </div>
+    </div>
+    <div class="lc-row me">
+      <div class="lc-meta"><span class="lc-name">Me</span> · October 24th, 2010 at 4:25 PM</div>
+      <div class="lc-bubble">
+        <p>So.. You’re saying Chiropractic cured Sleep Apnea.. Bullshit. Your husband slept 9 hours because the night before he couldn’t sleep due to previous suffering.. More over, you’ve likely been tired too if he’s waking up as often as you imply, so the reason he didn’t wake you with loud snoring isn’t because he wasn’t snoring, but because you were tired and stayed asleep..</p>
+        <p>This is more than likely a coincidental “cure” that I’m sure they are more than happy to take credit for..</p>
+      </div>
+    </div>
+    <div class="lc-row them">
+      <div class="lc-meta"><span class="lc-name">Toni</span> · October 26th, 2010 at 9:45 AM</div>
+      <div class="lc-bubble">
+        <p>I never said the chiropractic treatment cured his “sleep apnea”. But his sinuses are clear for the first time in 9 months and he has continued to sleep through the night since the treatment. During the past 9 months he has slept in 2 hour intervals because he had difficulty breathing. So I guess what I’m saying is clear sinuses has cured his “sleep apnea”. I doubt it was the chiropractic treatment that helped his sinuses as much as the acupuncture. My point was the “activator treatment” was obviously a scam. We became desperate for some relief for him which is why we went in the first place. He went to an acupuncturist/chiropractor 5 days ago and he has been able to breath and sleep ever since. We are very thankful for this treatment and hope he is on the road to recovery (he lost a lot of weight due to nausea from the sinus drainage). I wouldn’t have believed this would work either if I hadn’t seen it for myself.</p>
+      </div>
+    </div>
+    <div class="lc-row me">
+      <div class="lc-meta"><span class="lc-name">Me</span> · October 28th, 2010 at 11:44 AM</div>
+      <div class="lc-bubble">
+        <p>Okay so it sounds like you’re whole point is that Chiropractic didn’t and doesn’t work and that you think its a scam but Acupuncture does work.. Acupuncture which is also widely accepted as a scam..</p>
+        <p>I have no experience with acupuncture personally but I don’t understand how poking someone with a needle will clear their sinuses.. (unless you poke a large enough hole to allow drainage..) .. or anything for that matter..</p>
+        <p>Again, I’m skeptical at best.. Most likely any perceived effects of acupuncture are probably due to a combination of expectation, suggestion and other psychological mechanisms.. Aka Placebo.</p>
+      </div>
+    </div>
+    <div class="lc-row them">
+      <div class="lc-meta"><span class="lc-name">Jesse P.</span> · November 14th, 2010 at 8:18 PM</div>
+      <div class="lc-bubble">
+        <p>This is a good debate although i will say from experience that the TRUE chiropractic doctors are those of “upper cervical spine doctors” Other known as Atlas Orthogonal specialists. They address the root of the problem. Your atlas, which is the very first vertebrae that aligns the rest of your spine. Trust me i have suffered with a misaligned atlas for many years my symptoms ranging from intense cranial pressure, dizziness, neck stiffness, pain, vision problems, weird feelings in my head, irritability, general malaise and a few more. Also like you, my body shifted. My leg was not shorter but my shoulders where no longer parallel. When she first examined me she told me to stand still and close my eyes. When she told me to open them again my head (not consciously being aware of) was tilted to the right. She then proceeded to tell me about my misaligned atlas. When i took the x-rays, it was 11 degrees off, a severe case. So what happened is, she used the machine similar to the one you explained, the awkward position isn’t all that bad, so after putting the orthogonal machine, jammed close to my ears she pulled the trigger and soon after i felt the blood rush through my head and felt a calm feeling and my cold clammy hands slowly went warm i felt the positive effect. When i came out of my first visit i didnt feel all that good… I felt out of place a little weird. Even trouble swallowing. The next week i had went again and it turned out a little bit better that time. And that was it for my atlas It had stayed put and this is after only 2 treatments with the orthogonal machine. So now, this is where the magic begins, on the third visit, she proceeded to adjust my c5 for the first time which is very different from the regular chiros, There is no cracking or harsh manipulations, thats what i love about it. So anyway when she had gently adjusted me using the table to shift down and let gravity do its work all while laying down on the table looking slightly down, my left shoulder instantly had a radiating pain shooting down my left arm. I got a little scared but she reassured me.. I didnt feel immediate effects but after a couple of times after one day i remember going in and getting adjusted And felt amazing like my whole world had a different meaning a depth of field that i didnt know of, the colors where bright and vivid. So fast forwarding, after about 10 treatments every week it was once a month the quickly went to once every 6 months! which is good news as my atlas has stayed in place for 9 months!</p>
+        <p>Now heres the thing they dont tell you about. Is HOW to further improve your neck and spine. After many years of research ive come to the conclusion that posture is ESSENTIAL and NUTRITION. Keeping good posture while sitting and standing is key, but really when it comes to the developing of your spine, proper sleeping position is whats going to affect your posture the most, yes. A good firm bed and… No pillow. Thats right, as humans we didnt evolve with a pillow attached to us, no animal on this planet uses pillows. It is absolutely unnatural to prop up your head at night especially if you sleep on your stomach and back. On the sides its O.K but we tend to move at night so its no good. Babies when born have no pillows in order to develop the spine, to keep it in its natural alignment. As the baby grows and later on given a pillow this is the biggest mistake. When the person reaches around the 20′s You can differentiate the ones who had used a pillow and the ones who dont. Now the next thing to heal the neck is nutrition, i mean, proper nutrition! (this is coming from someone who was a vegan and a vegetarian) I wont get to much in this as you can read a whole page on this here:<a href="http://www.biblelife.org/neck.htm" target="_blank" rel="noopener">http://www.biblelife.org/neck.htm</a> (And no its not about religious beliefs)</p>
+        <p>Alright i hope after all of this you find your way in healing! Also dont forgot to check out more about primitive ways of sleeping and such. After 4 years of suffering and getting better again.</p>
+        <p>All the best Jesse P.</p>
+      </div>
+    </div>
+    <div class="lc-row them">
+      <div class="lc-meta"><span class="lc-name">Jack</span> · December 17th, 2010 at 1:20 PM</div>
+      <div class="lc-bubble">
+        <p>My prior chiropractor just told my friend that she should see a medical doctor because he thought she had a very bad kidney infection, which was true. Not all are bad and I have been to some snake-oil ones myself. Look for those who will take the time to TALK to you BEFORE asking for the $$$. Those are usually the ones who really care about their patients quality of life (no pun intented for Life University).</p>
+        <p>Oh, also, I had a computer repairman, who was recommenened to me by a computer programmer, who scammed me out of replacing my “motherboard” as the problem. So, look, listen, &amp; ASK before going to any “professional”, especially the 15 minute to 1 hour oldest profession ones!!!</p>
+      </div>
+    </div>
+    <div class="lc-row them">
+      <div class="lc-meta"><span class="lc-name">Ibuzz</span> · January 13th, 2011 at 5:26 PM</div>
+      <div class="lc-bubble">
+        <p>I went to a chiro in Southwest FL and it’s associated with Maximum Living – Dr. Loman. I felt like I was at a cattle feeding, in out in out came the families, little kids, wives, husbands, etc. I “won” a free consult, a $245 value, sat through the first and second visits, was told I’m in really bad shape and some of the crooked vertebra are linked to my thyroid and heart, so he’s really concerned. Tonight I was to go to another free meeting but I MUST bring my wife. We’ll sit in a room and watch a movie then go to a private room to see my X-rays then discuss treatment and money. I read one of these posts where they said they’ll throw out a high number then get you to agree to a huge discount but it’s still like $2500. I don’t know b/c I’m not going back. I have shoulder pain and could go for physical therapy as prescribed by my Orthopedic, but I wanted to try something else. Not now unless I literally go to a Chiro and ask if they treat me based on Subluxation. I believe some Chiro’s would treat the back and try and help the pain.</p>
+        <p>I’ve had an MRI on my shoulder and I have slight to moderate arthritic changes and tendentious. Can a Chiro help this or should I take the advise from the Orto and go to the Physical therapy?</p>
+      </div>
+    </div>
+    <div class="lc-row them">
+      <div class="lc-meta"><span class="lc-name">Chub</span> · February 11th, 2011 at 2:24 PM</div>
+      <div class="lc-bubble">
+        <p>Jason, I am seeing a chiropractor in South Austin for a neck injury. I am not ready to pass judgement yet but I do wonder if my neck pain would resolve on its own without the chiro. I’ll break down what has happened so far…</p>
+        <p>First Visit: various balance tests and movements to see if my injury is muscle or disc related. No Xrays or MRIs. Chiro feels confident it is disc as bending over and coughing was extremely painful, that was 2 weeks ago. Now it doesn’t hurt to do that unless I really push it. Also did sensory tests all over my body (pricking me and asking me for points). After the tests we did ice and an activator adjustment with me sitting up and he behind me making me bend my neck in certain positions.</p>
+        <p>Following visits: Either consist of ice and heat treatments with a roller table (I am lying on my back), in adddition to the alpha-stim machine attached to my skin. Also Physical therapy. I have done various balance exercises and neck exercises to strengthen the neck muscles he thinks let me get to where I injured my disc.</p>
+        <p>So to summarize I am still seeing him and will continue the PT exercises at the office and at home.</p>
+        <p>[Additional] I forgot to mention each visit he does an adjustment, either manual or activator. I am skeptical of the activator but he claims it is stimulating my receptors to help my brain rewire and stimulate the muscles there. (very chiropractor like talk) This is in addition to the PT. Each visit is about 40 minutes – 1 hour.</p>
+      </div>
+    </div>
+    <div class="lc-row me">
+      <div class="lc-meta"><span class="lc-name">Me</span> · February 11th, 2011 at 4:06 PM</div>
+      <div class="lc-bubble">
+        <p>Out of curiosity, was your chiropractor a “nice guy”.. in kind of a slimy used car salesman way? It seems a trend..</p>
+        <p>Either way, just to be clear.. You went to a Chiropractor with neck pain.</p>
+        <p>He then performed the shenanigan dance that is the chiropractic equivalent to triage and determined that you were a prime sucker..er I mean that you had an injured disc in your spine.. And he then started poking and prodding that area as well as applying ice/heat..</p>
+        <p>Wow.. where to begin;</p>
+        <p>Firstly, what type of Spinal Disc issue is he trying to say this is? Herniation? Protrusion? Bulge? Tear? Your “doctor” made a diagnosis of “hurt disc” which lets be honest here, is no diagnosis at all..</p>
+        <p>More over he made such a diagnosis without any x-rays and by making you do a balance test? really? So.. he put a scale under each foot and “proved” to you that you had a spinal issue because your weight didn’t span both scales 50/50? All that test proves is that you aren’t synchronous creature.. Shocker.. It’s almost like some of your organs internally aren’t perfectly aligned or are to one side or another of your body..</p>
+        <p>Seriously, If you actually had a serious disc issue the last thing you would have wanted was for some jack wagon to be poking you with a hammer..</p>
+        <p>If it truly was an injured disc, what exact was heat/ice supposed to do other than just make it feel a little better? Couldn’t you have done that yourself? All he has sold you is good feelings and he is taking credit for what nature was going to do all by itself.</p>
+        <p>The majority of herniated discs heal themselves in about six weeks and don’t require any form of surgery. Of course, Some do require surgery, but you wouldn’t even be able to move if you had that kind of injury and likely would have gone to the hospital in an ambulance..</p>
+        <p>It’s more likely you had a muscular issue or a minor disc issue that would have resolved itself with time..</p>
+        <p>I think you need to be very realistic with yourself and ask your self some serious questions; So you had some pain and you wanted relief now, sure.. I completely understand.. But what did the chiro really do for you that an ice pack or a heating pad, some motrin and time wouldn’t have done?</p>
+        <p>Nothing.</p>
+        <p>Cogent Historical Paradigm: Hundreds of years ago in primitive tribes, if you got sick you went to the witch doctor for a cure.. He sat you down, danced around you, blew smoke at you and shook a chicken foot over your head.. If you got better, the witch doctor cured you!! Man those witch doctors were awesome!</p>
+        <p>How is it different? We can’t prove that the witch doctor didn’t cure the individual. Just like I can’t prove that the chiropractor didn’t cure you..</p>
+        <p>But isn’t it more likely that this is a case of a professional scam artist that has nothing better to offer society than selling “good feelings” is trying to to take credit for your own bodies natural healing process?</p>
+        <p>I hope you get better, I really do.</p>
+      </div>
+    </div>
+    <div class="lc-row them">
+      <div class="lc-meta"><span class="lc-name">Chub</span> · February 12th, 2011 at 11:32 AM</div>
+      <div class="lc-bubble">
+        <p>Yes I am as skeptical about it as you are. I should re-explain the disc diagnosis.</p>
+        <p>disc diagnosis: He said if it is a herniated disc only 5% need surgery and it will heal over time on its own. The only thing he did with the disc check was I sat on the table with my legs parallel with the ground. Then I bent my head/back downward towards the ground and stop when I feel pain. Then he had me cough to see how bad the pain was. All of this is a sign of a disc injury. He did not request x-rays or MRI.</p>
+        <p>Following tests: We did some balance tests without any special equipment. No SAM machine or anything like that. If you google for the realage balance test it was like that. One foot up and eyes closed. Check each foot.</p>
+        <p>Another test was to check if my back goes flat when I lift my arms up while my back is close to and facing a wall.</p>
+        <p>The other tests were checking how tender my muscles were. He took this information and based the preceding physical therapy around it.</p>
+        <p>The heat/ice: I was already taking 800mg of Ibuprofen very 6 hours with ice a few times per day. We did the ice for the first 1.5 weeks when I go; honestly I think he does it because he can and ice helps with inflammation. And yes nobody needs a doctor to do that. Last visit was heat.</p>
+        <p>I am taking all this as a skeptic and being objective as I can. As I think some of the chiropractors are new day Shamans, like homeopaths.</p>
+        <p>I think where I am benefiting is from the physical therapy and correcting how I do a lot of forward leaning all day at the computer. He is emphasizing to teach me ways to be more ergonomic so I can prevent any future injury. Along with doing the exercises at home which I can continue without paying them.</p>
+        <p>The still feel the activator adjustment is nonsense.</p>
+      </div>
+    </div>
+    <div class="lc-row them">
+      <div class="lc-meta"><span class="lc-name">Anna</span> · February 27th, 2011 at 7:17 PM</div>
+      <div class="lc-bubble">
+        <p>I went to a chiropractor for the first time last week for a severe case of vertigo caused by an inner ear infection (viral labyrinthitis). The vertigo is not acute anymore in the sense that I can now walk and move my head without throwing up, but I still have dizziness, searing headaches, mental confusion, and a stiff neck. I read somewhere that adjusting the upper cervical spine can fix these problems, so off I went to a nearby chiropractor at a Wellness Center who had glowing reviews on Yelp. She had never heard of my condition and had to look through a medical textbook to find out what it even was. Then, after reading a bit, she said, “Well, it says here that antibiotics can sometimes help.” And I said, “Well, it wasn’t a bacterial infection, it was caused by a virus, so they didn’t give me antibiotics when I went to the ER.” Then she looked shocked and said “You mean you asked for antibiotics and they didn’t give them to you?” And I said, “No, they took a blood and urine sample, and determined that it wasn’t bacterial.” She then stared at me for a moment, and started to say, “You mean, they could tell by something in your blood…” then stopped, as she realized this made her sound like she knew nothing about medicine.</p>
+        <p>After having me stand in front of a mirror and move in certain ways, making various observations and comments, she had me lie face down on a table. She pressed on various points on my spine, asking me which of them felt “tender.” I didn’t understand what she meant, as everything on my back feels tender. So she pressed my hand, and said that I should feel no more than I felt when she pressed my hand. But the spine is where the nervous system is, I thought, so you’re always going to have more tenderness there than on your hand. But I tried to answer her as well as I could. As she went up my back to my neck I would answer more in the affirmative, that one disc or another was tender, and she rewarded me with, “Good, you’re getting the hang of it.” I thought her method of testing would be more scientific than this, for instance, an x-ray or computer imaging or something. But she merely wrote down my answers to what felt “tender,” some of which might have been arbitrary, and marked down which vertebrae they corresponded to.</p>
+        <p>The she held one arm up while tapping on my wrist. She also touched and brushed me on various parts of my body very lightly. She made verbal assertions as she did this: “You definitely have a virus…you live through other people- you need for others to be happy before you can be happy – this is a problem mostly in the workplace…” etc. Then she took a bottle of pills and held it against my stomach, all the while holding and tapping my wrist. “No, you don’t need these…” Another bottle of pills: “Three times a day.” Yet another: “Three times a day.” After that she used that activator machine and clicked on my face near my sinuses, which actually hurt quite a bit, then did some adjustments. She pulled both my ears out until they made sickening popping sounds: “It shouldn’t make a sound like that. It means you have a kink in your Eustachean tube. Now it’s straightened out.” (I later looked it up and I could find nothing in medical literature whatsoever about the existence of kinks in the Eustachean tube). Then she cracked my neck one way, and then the other. (OUCH)! Afterwards she said, “Well, we’ve done a lot today, doing any more would be too much for you. We adjusted your neck and your ears, we cleared viruses…” I was astonished. “You mean, you were able to clear viruses just by that tapping you were doing?” Her reply: “Well, basically, when you have a virus your body shuts down, so what I did was talked to your body and let it know the virus is there, so it can take care of it.” I said, as credulously as I could, “Oh, I see.”</p>
+        <p>Then she had me sit in a complimentary aqua detox foot bath, where you soak your feet in water in a machine for 30 minutes, or until the water turns black. The receptionist came in and said, “Oh, all that black is from smoking, or from living with second hand smoke.” I said “I don’t smoke and I’m never around second hand smoke.” She looked flustered and then said, “Well, then maybe it’s just pollution. And the orange is from your liver.” The “doctor” then wanted to know whether I would complete the full 6 session aqua detox at $50 a pop, and seemed cross when I said no, not right now. (The same foot detox machine she uses in her office can be bought on Amazon for $150, and 6 sessions in her office would have cost $300). The machine claims to detoxify your body, but has mostly been proven to be a scam. All it did was make my feet very clean.</p>
+        <p>While paying, the receptionist scheduled another visit for a few days later, and charged me for the two bottles of pills. I looked at one bottle – oregano capsules – and thought, what the heck, I know oregano is supposed to good for the immune system, so I’ll try it. But the other was for an antioxidant vitamin. I said to the receptionist, “I don’t know if I need these, I already take a vitamin supplement.” The chiropractor overheard me and said, “Well does your vitamin contain zinc? It’s well -documented that zinc helps with viruses.” I said “I don’t know.” She asked, “did you take your vitamin today?” I replied, “yes.” She rejoined sternly, “well, obviously you don’t get enough zinc, because your body tested for it.” I didn’t want to argue, so I bought the expensive little bottle of pills. Her voice had so much authority when she said that I tested for it. What was the test? That thing she did where she whooshed the bottle over my stomach and felt the vibes? (When I got home I saw that my multivitamin actually has more zinc than her supplement).</p>
+        <p>She scheduled me the next day for an acupuncture visit in the same office. When I ran into her in the waiting room, I asked her if she really thought my vertigo was related to my neck. She said, “Of course, it’s from years of injury from having bad posture.” (I had told her myself the day before that I thought I had neck damage from years of bad posture). She added, “That’s why you have a dowager’s hump.” After I finished my acupuncture treatment, which left a terrible black bruise under one eye, I went home and Googled “dowager’s hump,” and found that a dowager’s hump is an advanced state of osteoarthritis that leaves old women with hunchbacks. It is a real medical condition that can’t be reversed as there is so much bone loss, which never occurs in people of my age. It is however related to something called a “thoracic hump” which younger people do get, but which is a VISIBLE hump on the back from bad posture (there is no visible hump on my back).</p>
+        <p>I cancelled my next appointment with her after this, and will not be going back. Aside from the high cost of the first visit (the first visit is $165, whereas followup treatments are $55), my vertigo seems to have gotten considerably worse. I now have a new symptom, which is a fluttering inside my ear which sounds like a moth trying to get out. I looked up this symptom and it’s called tinnitus and is a result of vestibular damage. I’ve had my vertigo for two months now and never until now suffered tinnitus, which is a potential side effect of an inner ear infection and can lead to permanent deafness. I’m sure it was a result of damage that occurred when she pulled my ears. My neck pain is also worse, so bad that now I can’t sleep and sometimes actually cry out in pain just when turning my head on the pillow. Would subsequent visits fix all that? I don’t know, but after the careless way in which she pulled on my ears, having no idea whether it would damage them further or not, I’m afraid of her and don’t want to find out.</p>
+        <p>As a side note, I was not surprised by her shenanigans with passing the pills over my stomach, because two people I know had already told me stories about their chiropractors using this method to prescribe medications and treatment. It’s called “applied kinesiology,” and apparently a large number of chiropractors today use it. I wanted to add this story because no one yet had talked about this method, which more than anything else seems like a witch-doctor sort of practice.</p>
+      </div>
+    </div>
+    <div class="lc-row me">
+      <div class="lc-meta"><span class="lc-name">Me</span> · February 27th, 2011 at 7:38 PM</div>
+      <div class="lc-bubble">
+        <p>Holy crap! That’s a great story, and an awful one.. I seriously hope she didn’t hurt you..</p>
+        <p>I’d go see a doctor, and then a lawyer.. It’s quite possible she actually made you worse or at the very least did nothing but bilk you out of your hard earned cash all in the name of “curing you”..</p>
+        <p>It’s amazing to me.. How can these people live with themselves?</p>
+      </div>
+    </div>
+    <div class="lc-row them">
+      <div class="lc-meta"><span class="lc-name">Dr. Amy</span> · April 2nd, 2011 at 20:23</div>
+      <div class="lc-bubble">
+        <p>First off, you must understand that there are good doctors and bad doctors in every field. This D.C. may not have had a good “bed-side manner” and was terrible about educating patients on what exactly they were doing. I’ll also admit that some of my colleagues have some strange methods, but that is why you do your homework and go to a doctor with good references just like you would a medical doctor. Chiropractic treatment is definitely more broad in it’s options where Allopathic medicine (seeing an M.D.) is more like symptom ABC gets prescription 123. Very cut and dry.</p>
+        <p>As far as education goes, Check this out:</p>
+        <p>[ Removing the link. I don't want to give these quacks the hits. ]</p>
+        <p>The school I went to covers Anatomy, Physiology, Chemistry, Diagnosis, X-ray and Orthopedics in WAY more detail than med schools. And Med schools cover Pathology, Ob/Gyn, and Psychiatry WAY more than Chiro school. The differences are to be expected due to the nature of our work.</p>
+        <p>As for safety of a Chiropractor, some may find it interesting to know that a Chiropractor’s malpractice insurance is OVER 5 TIMES LESS than any medical doctor’s (at minimum). Insurance premiums are directly related to risk (hence the reason our car insurance is so high due to my speed demon husband) so it can be assumed that seeing a Doctor of Chiropractic is over 5 times less risky than seeing a medical doctor. Just saying…</p>
+      </div>
+    </div>
+    <div class="lc-row me">
+      <div class="lc-meta"><span class="lc-name">Me</span> · April 4th, 2011 at 11:58</div>
+      <div class="lc-bubble">
+        <p>*sigh*</p>
+        <p>First off; You link a chiropractic website as proof that chiropractors are some how more educated and know more than real medical doctors. It’s propaganda, pure and simple. The website is owned by a chiropractor.. Hrmm.. More over, there aren’t any such MD websites that countermand this bold (and stupidly false) statement because they don’t need them.</p>
+        <p>Medical doctors not only know more, but do more for you and they have no need to prove it through propaganda or shenanigans.. Chiropractors do, and do so constantly because they know their image is shady as hell..</p>
+        <p>( What makes it seem so shady? I dunno maybe everyone’s bad experiences with the profession or people with a 2 year degree coming along making bold statements about how much more they know than MD’s all while demanding to be called Doctor.. Just saying.. )</p>
+        <p>To say that the school you went to covers anything more thoroughly than a medical school is down right ludicrous.. What school is it? How long did you attend? What’s the normal course length to graduate as a DC there? What was your courses and specific field of study? How many hours did you study Chemistry? How many hours did you put into X-Ray.. etc.. Go on answer, lets put your claims to the test.. I call bullshit and doubt I’ll hear from you again on the matter.</p>
+        <p>As to malpractice insurance, your argument is sort of like saying it costs less to insure a Ford Escort than it does a Mercedes SLS therefore the Ford Escort is clearly better.. huh? Of course medical insurance is more expensive. Medical insurance has to be high because many of the procedures that they do can be invasive and risky.</p>
+        <p>That’s because medical doctors ACTUALLY DO SOMETHING!!</p>
+        <p>Name one thing that a chiropractor does that is as invasive as say; Surgery. Removing an appendix can be risky and can’t be fixed by chiropractic methods no matter what some douche bags say. (I found a link but I refuse to give him the hits.. just google it.)</p>
+        <p>So to that point, I will agree with you; Chiropractic exams and treatments aren’t very risky at all!! In fact I would say you’re at more risk driving to the chiropractors office, than actually being treated. But then thats because they don’t do anything. They massage you a little, maybe pay attention to you for a few minutes, poke you and prod you, and charge you for the good feelings and CO2 you just got.. They didn’t do anything other possibly enable the placebo effect.</p>
+        <p>The risky part with any chiropractic “treatment” is and always has been the notion that the “care” you just got is supposed to cure something that is really very wrong and that for which you should have sought real honest medical care.</p>
+      </div>
+    </div>
+    <div class="lc-row them">
+      <div class="lc-meta"><span class="lc-name">Dr. Amy</span> · April 4th, 2011 at 22:32</div>
+      <div class="lc-bubble">
+        <p>If you want to, look up the prerequisite requirement and curriculum for UT Southwestern Medical School compared to Parker College of Chiropractic. My school was 3 years long, BUT we don’t get summer vacation like the med students who go for 4 years. I was on a different plan than the current students and had to finish in 9 trimesters vs 10 so I took an average of about 30 hours a semester plus all of my clinic hour requirements. As far as course of study, how many hours, etc., do the comparison yourself if you like. I don’t have time to itemize these for you and you seem to be quite passionate about your hatred for Chiropractic, so I have no doubt that you might actually do it. LOL</p>
+        <p>And you are totally missing the point of my argument about insurance. Medical doctors try to say that Chiropractic is dangerous, yet our malpractice insurance is significantly lower. My husband’s car insurance is significantly more expensive than mine because he has so many speeding tickets. He is more likely to wreck his car or hurt himself of someone else. He’s higher risk, hence the higher insurance. That was my point.</p>
+        <p>The are lots of people that have had awesome results from Chiropractic care. People who were told they needed surgery, avoided surgery and are now pain-free. People crippled by headaches are no longer getting headaches. On the other hand there are some that need medical care and are simply not going to get better with Chiropractic alone. I personally choose to use a medical doctor that practices homeopathy on the rare occasion that my family needs medical attention. He doesn’t give the mainstream drugs like all the rest of them do, he uses homeopathic remedies and diet to treat his patients but he’s effective just like myself and colleagues are effective especially with many musculoskeletal issues . Some D.C.s believe that Chiropractic can treat absolutely any issue. I’d have to say I disagree, but google something about Chiropractic helping and you will find millions of success stories whether or not you choose to believe it. If you don’t like Chiropractic, the solution is simple: don’t go see a Chiropractor! Hahaha!</p>
+        <p>“Real honest medical care,” HAHAHAHAHA!! If you are up for it, I got two videos for you. Food Matters and The Business of Being Born. We’ll see what you think about “real honest medical care” then, my angry friend! Happy blogging!</p>
+      </div>
+    </div>
+    <div class="lc-row me">
+      <div class="lc-meta"><span class="lc-name">Me</span> · April 4th, 2011 at 23:26</div>
+      <div class="lc-bubble">
+        <p>Lets look at the average MD and their schooling: It typically takes 4 years of undergraduate school to obtain your bachelor’s, followed by an additional 4 years of medical school and then several years of internship before you can even wear the title of MD. On average in the United States, it takes up to 12 years to reach the status of MD.</p>
+        <p>More over, all MD’s are required by their individual state to participate in ongoing education to make sure their skills stay sharp and that their knowledge is current. They are required to attend yearly classes, in-service training, and seminars. The simple fact of the matter is, as a MD you are never done with school.</p>
+        <p>Each state varies with the requirements and schooling, though not by a lot as I understand it.</p>
+        <p>So suddenly that 3 year degree isn’t all that impressive.. I don’t mean to take anything away from you as it sounds like you worked very hard to get the degree, but I question the value.</p>
+        <p>Either way, the above explains why your raw comparison of curriculum doesn’t even mean anything.. its apples vs oranges.</p>
+        <p>As to your allegation that MD’s are going around spreading vicious rumors about how dangerous chiropractic is, I’m not seeing it. Is there a danger, sure.. there is danger in anything.. but aside from the odd stroke warning there doesn’t seem to be a huge outcry from MDs defaming DCs or their practices.</p>
+        <p>Interesting that the opposite isn’t true.</p>
+        <p>As to Homeopathy.. OH dear god — Are you serious? Have you done any research what so ever as to what Homeopathy is and how it came about?</p>
+        <p>For a good chuckle, watch this video of James Randi explaining all about Homeopathy and then seriously do some research and reconsider.. He’s 100% truthful and honest.. <a href="http://www.youtube.com/watch?v=BWE1tH93G9U" target="_blank" rel="noopener">http://www.youtube.com/watch?v=BWE1tH93G9U</a></p>
+        <p>Long story short: Samuel Hahnemann during the medical dark ages (a couple hundred years ago) called himself a doctor, prepared “medicine” of his own invention following his four absurd rules and sold it to people for profit.. He was a snake oil salesman.. Hrmm isn’t that exactly what Daniel Palmer did with his “innate intelligence”..</p>
+        <p>Ha! <a href="http://www.randi.org/encyclopedia/chiropractic.html" target="_blank" rel="noopener">http://www.randi.org/encyclopedia/chiropractic.html</a></p>
+        <p>Thank you James.</p>
+      </div>
+    </div>
+    <div class="lc-row them">
+      <div class="lc-meta"><span class="lc-name">Dr. Amy</span> · April 5th, 2011 at 13:02</div>
+      <div class="lc-bubble">
+        <p>Most medical schools do NOT require a bachelor’s degree up front. They require specific prerequisite classes which are identical to the ones required for Chiro school so most D.C.s have a prior bachelor’s degree but a few don’t just like med students. D.C.s also have to do several hours a year in continuing education so that their “skills stay sharp and that their knowledge is current.” As I mentioned before, the three years is without summer breaks so it’s about equal in the time spent in class and if you decide to go on to a more specialized practice such as radiology, you can go to school for an additional 5 years and become a Chiropractic Radiologist (DACBR) or get you could choose to get a diplomate in Neurology, Pediatrics, Sports Practioner, Functional medicine, etc, etc which most do specialize in one way or another depending on their interests requiring hours and hours of additional study. So your argument about education just doesn’t hold up.</p>
+        <p>Allegations of MDs against DCs is a huge deal whether or not you are “seeing it.” LOL There are blogs, papers, hell, even pamphlets and even billboards that M.D.s have posted about the “dangers of Chiropractic” that make people fearful of us, but that’s really not important to our current argument.</p>
+        <p>I have a couple of thing for you to think about. 1. I use a radiology center to do all of my x-ray/MRI because I choose not to invest in the equipment when I can use theirs down the street. When I send a patient there I get a report from an M.D. radiologist as well as a Chiropractic radiologist. The M.D.s report is usually about a paragraph and the D.C.s is about a page or more. A patient came in because he has shoulder pain radiating from his neck and numbness in his tongue. I sent him for xray and the D.C.s report described in great detail the surgery, knew that the surgery was to correct a Chiari malformation and suggested the patient return for MRI bc with that surgery and considering the symptoms he was having, he was concerned because some patients develop a cavity in their spinal cord after this particular issue which can put them in a wheelchair as a paraplegic within a few years. The M.D. didn’t so much as mention the “hardware” still left from the surgery he had on his skull and 1st vertebrae. Now tell me who the “quack” is in this situation? This Chiropractor quite literally saved this guy’s life as he knows it because if we had just had the M.D.s report this could have turned into a reversible situation but he can now get it taken care of.</p>
+        <p>2. I was actually supposed to be an entering freshman at UT Southwestern medical school and even had all of my financial aid approved and ready to go until I had a run-in with a neurologist that completely changed my thinking. I had dizzy spells and headaches and after a CT, MRI, and MRA with this neurologist, I was told that I “just have migraines” like my mother and that I needed to take 2 different kinds of medications with extensive lists of side effects in order to control them. I disagreed as I had done my own research and suggested the possibility of something called cerebral pseudotumor which the doc disagreed over and over again. I tore up the prescriptions and went to my Chiropractor. He went over the radiology reports from the 3 scans I’d had and pointed out that even the radiologist had listed several things that were “congruent with cerebral pseudotumor and needed to be followed up clinically.” The neurologist didn’t even see this statement because he didn’t even LOOK at my reports. The Chiropractor made some suggestions to help my problem naturally and, guess what? It worked!!! I decided that I didn’t even want to have access to medicine because I wanted to challenge myself to treat everything as naturally as possible. I called up UTSW and told them to cancel my financial aid and called Parker college. Who’s the quack? I shouldn’t even have to ask…</p>
+        <p>The thing is there are “quacks” in all areas. There are crappy Chiropractors, crappy Dentists, crappy Physical therapists, and even some crappy Medical doctors. I could go on an on especially with stories from when I worked in the hospital, but I have a patient on his way for a follow-up who was scheduled for surgery to fuse C4-5-6 but cancelled because after 3 treatments Chiropractic has reduced his pain by about 75% and eliminated the numbness and tingling in his right arm. But that could not have been with my help, because I don’t do anything right??!! I am just some dumb Chiropractor with a sub-par education! LOL</p>
+        <p>As for homeopathy, if you don’t like it and don’t believe in it, just like Chiropractic, don’t go! LOL A little colloidal silver and one homeopathic remedy and my daughter’s bilateral eye infection was gone in less than 24 hours. I’m in! Medical doctor would have given us an antibiotic which also would have worked but I prefer not to use those unless absolutely necessary because those are abused so much that their effectiveness is going down the toilet slowly but surely hence the danger of MRSA in hospitals. But to each is own. If you like popping pills from your M.D., then by all means, do it!</p>
+        <p>I have really enjoyed our little argument run we’ve had. I don’t remember how I can across your blog. I wasn’t looking for anything like this, just came upon it by accident. The funny thing is that as much as you are trying to discredit me and my profession, it’s actually making me stronger because if someone puts me on the spot with an argument similar to any of yours I can recall things that I said to you quickly as it’s fresh in my brain and debunk their arguments very effectively. LOL Maybe I’ll just crash more blogs if I find any similar or create one of my own. Haha!</p>
+        <p>Happy blogging, Jason!</p>
+      </div>
+    </div>
+    <div class="lc-row me">
+      <div class="lc-meta"><span class="lc-name">Me</span> · April 5th, 2011 at 15:26</div>
+      <div class="lc-bubble">
+        <p>After doing some more research it seems you’re right about the bachelors degree and medical schools. I will concede the point that in order to be a MD you don’t need to have a BA. I was misinformed. However, you have yet to prove to me at all anywhere that DC’s are some how more educated than an MD which seemed to be your point above.</p>
+        <p>More over, no where did I call you a “dumb chiropractor with a sub-par education”. If you choose to be offended then that’s on you. The fact of the matter is you’re likely more educated than I am. What I post here are my observations and opinions and as such they are my own, yet it’s interesting how many other people out there with absolutely no ulterior motive is also “trying to discredit you and your profession”. If I were a MD and bashing DC’s then you could easily dismiss anything I said as professional rivalry, but that isn’t the case.</p>
+        <p>As to the danger of chiropractic procedures, my previous statements stands and no one has been able to counter it; those chiropractors that use “strange methods” to use your words and sell only good feelings, some attention and CO2 are a danger to their patients because they are using big scary words and funky devices to convince good people that they need some unnecessary procedure. The “doctors” then charge exorbitant fees for said treatment over the course of sometimes months all the while couching those proceedings in good will and trust. That makes them sham artists and those kinds of shenanigans DO go on whether you practice them or not.</p>
+        <p>They are a danger to their customers because those individuals feel that they have gone to an expert who has their individual issue in hand and it’s being treated. When instead all they are doing is being taken advantage of and their medical needs are going unmet potentially worsening their condition. If you don’t do this then bully for you, but you’re clearly the minority. You have only to read the comments on this post to see all of the other folks who have had shady dealings with people in your profession. Or google it.</p>
+        <p>I’m sure chiropractic procedures have come a long way in the last hundred years, but the truth of the matter is they would have to considering chiropractic treatments were developed and defined by an inventor (Daniel D. Palmer) who was a new age healer who swore by the healing power of magnets and his ability to manipulate the immaterial spiritual essence that courses through our nervous system called “Innate intelligence”. Do you preach this to your customers? Do you wave magnets over people and tell them they are cured? Probably not, but there are those that do.</p>
+        <p>Ask yourself this; why would chiropractors need to redefine an orthopedic term to mean something else completely unless there was a plan to use it to bewilder and scare?</p>
+        <p>The cornerstone of modern chiropractic procedures and triage seems to be the subluxation. A bullshit term that they constantly define and redefine to be painfully vague, scary and completely unverifiable through any other means.</p>
+        <p>An orthopedic subluxation is a partial dislocation of a joint and as such is extremely bad and completely verifiable through image studies. A chiropractic subluxation is this theoretic problem that isn’t visible on any image study or remotely verifiable by any means other than apparently to make people stand on scales to check their weight or check to see if one leg is longer than another..etc.. Oh and to take the “doctors” word for it that you desperately need his help!</p>
+        <p>Its bullshit. It’s complete bullshit. You know it and I know it.</p>
+        <p>So, what about subluxations? How often have you told a customer that they have a subluxation? Because if you have ever said it, even once, you are a fraud. Period.</p>
+        <p>If you aren’t one of those DC’s then fine you’re one of the good ones.</p>
+        <p>“As for homeopathy, if you don’t like it and don’t believe in it, just like Chiropractic, don’t go.”</p>
+        <p>Here we go again, you have to “believe” in this treatment for it to work.</p>
+        <p>As I said above, that’s not medicine.. If I don’t believe in penicillin or Advil, it still works.. Yet for some reason for me to get any benefit out of your chiropractic treatments or homeopathy preparations I have to “believe”?</p>
+        <p>Requiring blind faith in some treatment for it to work is no different than what extreme religious faiths and cults do with their faith healing. It’s absolutely no different. Any and all perceived or actual benefits can be entirely explained by the placebo effect or the bodies own ability to heal itself with time. I just find it interesting how many homeopaths or chiropractors will be more than happy to take credit (and charge) for said results.</p>
+        <p>In my very first comment I stated; “I’m willing to concede that there are likely some chiropractors that aren’t complete fakes. But the methods they employ MUST be radically different than the ones I have seen so far.”</p>
+        <p>And that still holds true, but it’s apparent to me and those who seem to agree with me through this post and through countless others that the vast majority of the chiropractors out there are frauds with no more noble intent than to bilk the next sucker out of some money.</p>
+        <p>I am not a one man crusade out to crush a profession. There seems to be a rather large number of shady chiropractors out there as is evidenced by all the similar stories to mine, maybe instead of arguing with me you should urge those folks to fix their image and stop making your profession look bad..</p>
+        <p>I find it interesting that instead you seem to prefer trying to make me change my tune than to make them change theirs.</p>
+      </div>
+    </div>
+    <div class="lc-row them">
+      <div class="lc-meta"><span class="lc-name">Dr. Amy</span> · April 5th, 2011 at 21:12</div>
+      <div class="lc-bubble">
+        <p>I never intended to prove that DCs are MORE educated, just that we are not LESS educated than MDs which was your argument all along.</p>
+        <p>As far as Chiropractors giving unnecessary treatments to patients I agree it definitely happens. Hell, I dropped my “mentor” because I believed he was over-treating, but you can argue that medical doctors have been known to do the same thing, a more specific example is when it comes to surgery. Orthopedic surgeons are in the business of doing surgery. That’s how they make their money. I’ve met tons of people who had surgery and still suffer from the issue they went under for. Some have had multiple surgeries for the same thing. Did they need the surgery? Maybe, maybe not. But they trust the doctor’s judgement regardless. I’ve also treated tons of people whom have been told they needed surgery, and through Chiropractic care, no longer suffer any pain or symptomatology and have not gone on for surgery. And I didn’t even use magnets or shake chicken bones or give them snake oil! LOL I’m not saying two wrongs make a right by any means, but simply pointing out that we must be cautious with who we trust with our healthcare. If someone wants to go to a Chiropractor or ANY doctor, I recommend they talk to friends and or family and choose one that suits them.</p>
+        <p>“Belive” was a BAD choice of wording on my part. I should have known you’d run with that. Haha! If there is a placebo effect in my office, it’s minimized by my methods which I believe to be similar to most of my colleagues. In my practice I take photographs of my patient’s posture before their first treatment and every few treatments and also take measurements of ranges of motion to get an unbiased, numerical reading of their progress just to name a couple of examples. This is allows me to show my patients whether (or not) we are helping. If we’ve reached a plateau in progress we change things up, add exercises, stretches etc. if they even need to continue care at all. Because I know about a thousand more Chiropractors than you do, I am confident to put you at east that you are incorrect in your assumption that a “vast majority” of Chiropractors practice the more outlandish techniques. My last trimester of school 2 students out of about 100 were reprimanded for treating patients with some of these methods you must be referring to. This is definitely not the norm and schools are taking steps to minimize this. I can only assume that your assumption is solely based on blogs and threads you’ve seen on the internet and it’s a fact that people whom have bad experiences are far more likely to speak up than people who had a good one. For instance, if you went to a restaurant and saw a rat or bug crawl across the kitchen floor, you might tell 5 people, but if you went to a restaurant that seemed completely clean you wouldn’t tell anyone because there was nothing of concern. That’s just human nature.</p>
+        <p>I’m sure you are correct in that lots of people have had “shady dealing” with DCs and you encouraged me to google that. Well, I encourage you to google the positive experiences too as well as “shady dealings” with other types of docs such as orthopedic surgeons. (I just searched the latter and found a TON of articles about unnecessary surgeries) And next time you lean over to pick something up and one of your paraspinal muscles spasms causing one of your lumbar vertebrae which it’s connected to to get yanked to one side sending horrible pain down the back your butt into the back of your leg due to a nerve impingement, go to your MD and get some muscle relaxers and a pain killer if you like and don’t mind the side effects of. My patients can continue to come to my office when this happens and I can give them immediate relief by fixing the problem at it’s source (the spinal fixation or “subluxation” as some of my colleagues call it) as well as teach them ways to prevent that from happening in the future. (By the way that ‘s’ work has created a huge divide amongst our profession and I personally prefer not to use it… shhhh!!)</p>
+        <p>As far as arguing with you, that’s just for sport  The truth is I like you Jason. You are a very good debater. I like to think I am too and I love a challenge so I am thoroughly enjoying myself and learning a ton from you about how some of the public may view my profession and how I can work to better it. I’ve also been brainstorming ideas for my website, newsletters and health talks, so I thank you for that!</p>
+      </div>
+    </div>
+  </div>
+</section>
 
 ---
 

--- a/_sass/_post.scss
+++ b/_sass/_post.scss
@@ -229,6 +229,72 @@ $po-line:    #ddd;
     }
   }
 
+  // ════════════════ LEGACY COMMENTS (iMessage-style) ════════════════
+  // The old blog's comment thread, rendered as a chat: the author's
+  // replies ("me") are blue bubbles on the right, everyone else's are
+  // grey bubbles on the left.
+  .legacy-comments {
+    margin-top: 2.5rem;
+    padding-top: 1.5rem;
+    border-top: 1px solid #eee;
+  }
+  .lc-heading {
+    font-size: 1.15rem;
+    font-weight: 800;
+    letter-spacing: -0.01em;
+    margin: 0 0 0.2rem;
+    color: $po-ink;
+  }
+  .lc-note {
+    font-size: 0.85rem;
+    color: #8a94a6;
+    margin: 0 0 1.4rem;
+  }
+  .lc-thread {
+    display: flex;
+    flex-direction: column;
+    gap: 0.85rem;
+  }
+  .lc-row {
+    display: flex;
+    flex-direction: column;
+    max-width: 82%;
+    @media (max-width: 600px) { max-width: 92%; }
+    &.them { align-self: flex-start; align-items: flex-start; }
+    &.me   { align-self: flex-end;   align-items: flex-end; }
+    // group consecutive bubbles from the same side a little tighter
+    & + &.them, & + &.me { margin-top: -0.35rem; }
+  }
+  .lc-meta {
+    font-size: 0.72rem;
+    color: #97a1b2;
+    margin: 0 0.55rem 0.22rem;
+    .lc-name { font-weight: 700; color: #6b7688; }
+  }
+  .me .lc-meta .lc-name { color: $po-accent; }
+  .lc-bubble {
+    position: relative;
+    padding: 0.6rem 0.9rem;
+    border-radius: 18px;
+    line-height: 1.42;
+    font-size: 0.95rem;
+    word-wrap: break-word;
+    box-shadow: 0 1px 1px rgba(0,0,0,0.06);
+    p { margin: 0 0 0.5rem; }
+    p:last-child { margin-bottom: 0; }
+  }
+  .them .lc-bubble {
+    background: #e9e9eb;
+    color: #16181d;
+    border-bottom-left-radius: 5px;
+  }
+  .me .lc-bubble {
+    background: $po-accent;
+    color: #fff;
+    border-bottom-right-radius: 5px;
+    a { color: #fff; text-decoration: underline; }
+  }
+
   // ════════════════ AI SLOP-O-VISION BAND ════════════════
   // Full-width dark band that breaks out of the .post-article
   // padding (2.5rem desktop / 1.5rem mobile) to run edge-to-edge.


### PR DESCRIPTION
## What

The legacy comment thread on **Subluxation: A Chiropractic crock of shit!** was imported as indented text — which Kramdown rendered as grey monospace **code blocks**, with bare `Name - date at time` header lines above each. It read badly.

This reformats the whole thread (**56 comments**) into a chat-style UI:

- **Author replies → blue bubbles, right-aligned** ("Me")
- **Everyone else → grey bubbles, left-aligned** (their name)
- Each bubble gets a small **name · date** label above it
- Consecutive same-side bubbles tuck together slightly (iMessage feel)
- Bare URLs inside the imported comments are now clickable links

## How

- Parsed the `#### Legacy Comments` block in the post into semantic HTML (`.legacy-comments` → `.lc-thread` → `.lc-row.me/.them` → `.lc-bubble`). The `#### Links` section below it is untouched.
- Added scoped `.legacy-comments` / `.lc-*` styles under `.post` in `_sass/_post.scss` (reuses the existing $po-accent blue).

## Verify

- `jekyll build` clean; 19 "me" + 37 "them" = 56 bubbles render; no leftover `icon-star`/code-block markup; Links section preserved.
- Preview: http://localhost:4000/post/subluxation-a-chiropractic-crock-of-shit/ (scroll to the bottom).