### PR TITLE
Live comments via giscus, styled as iMessage bubbles

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -15,8 +15,8 @@ default_image: /assets/images/rsow-default.jpg
 giscus:
   repo: "palamedes/RSOW"
   repo_id: "R_kgDOSCxkQg"
-  category: "General"
-  category_id: "DIC_kwDOSCxkQs4DA_7l"
+  category: "Announcements"
+  category_id: "DIC_kwDOSCxkQs4DA_7k"
   mapping: "pathname"
   strict: 1
   reactions_enabled: 1

--- a/_config.yml
+++ b/_config.yml
@@ -8,6 +8,19 @@ permalink: /post/:title/
 # Fallback image for posts without a featured image
 default_image: /assets/images/rsow-default.jpg
 
+# Comments — giscus (GitHub Discussions). Comments render on a post only when
+# repo_id AND category_id below are filled in (get them from https://giscus.app
+# after enabling Discussions on the repo + installing the giscus GitHub App).
+# Per-post opt-out: set `allow_comments: false` in the post's front matter.
+giscus:
+  repo: "palamedes/RSOW"
+  repo_id: ""            # <-- fill from giscus.app (e.g. R_kgD...)
+  category: "Comments"   # the Discussions category giscus should post into
+  category_id: ""        # <-- fill from giscus.app (e.g. DIC_kwD...)
+  mapping: "pathname"
+  reactions_enabled: 1
+  input_position: "top"
+
 # Build
 markdown: kramdown
 sass:

--- a/_config.yml
+++ b/_config.yml
@@ -14,12 +14,14 @@ default_image: /assets/images/rsow-default.jpg
 # Per-post opt-out: set `allow_comments: false` in the post's front matter.
 giscus:
   repo: "palamedes/RSOW"
-  repo_id: ""            # <-- fill from giscus.app (e.g. R_kgD...)
-  category: "Comments"   # the Discussions category giscus should post into
-  category_id: ""        # <-- fill from giscus.app (e.g. DIC_kwD...)
+  repo_id: "R_kgDOSCxkQg"
+  category: "General"
+  category_id: "DIC_kwDOSCxkQs4DA_7l"
   mapping: "pathname"
+  strict: 1
   reactions_enabled: 1
   input_position: "top"
+  loading: "lazy"
 
 # Build
 markdown: kramdown

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -80,6 +80,34 @@ layout: default
       </footer>
       {% endif %}
     </article>
+
+    {%- comment -%}
+      giscus comments (GitHub Discussions). Shown unless the post opts out with
+      `allow_comments: false`, and only once site.giscus.repo_id / category_id
+      are configured in _config.yml. Styled as chat bubbles via the custom
+      theme at /assets/css/giscus-imessage.css.
+    {%- endcomment -%}
+    {%- assign gc = site.giscus -%}
+    {%- if page.allow_comments != false and gc and gc.repo_id != "" and gc.category_id != "" -%}
+    <section class="post-comments" aria-label="Comments">
+      <h2 class="post-comments-title">Comments</h2>
+      <script src="https://giscus.app/client.js"
+        data-repo="{{ gc.repo }}"
+        data-repo-id="{{ gc.repo_id }}"
+        data-category="{{ gc.category }}"
+        data-category-id="{{ gc.category_id }}"
+        data-mapping="{{ gc.mapping | default: 'pathname' }}"
+        data-strict="0"
+        data-reactions-enabled="{{ gc.reactions_enabled | default: 1 }}"
+        data-emit-metadata="0"
+        data-input-position="{{ gc.input_position | default: 'top' }}"
+        data-theme="{{ '/assets/css/giscus-imessage.css' | absolute_url }}"
+        data-lang="en"
+        crossorigin="anonymous"
+        async>
+      </script>
+    </section>
+    {%- endif -%}
   </div>
 </div>
 

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -97,12 +97,13 @@ layout: default
         data-category="{{ gc.category }}"
         data-category-id="{{ gc.category_id }}"
         data-mapping="{{ gc.mapping | default: 'pathname' }}"
-        data-strict="0"
+        data-strict="{{ gc.strict | default: 1 }}"
         data-reactions-enabled="{{ gc.reactions_enabled | default: 1 }}"
         data-emit-metadata="0"
         data-input-position="{{ gc.input_position | default: 'top' }}"
         data-theme="{{ '/assets/css/giscus-imessage.css' | absolute_url }}"
         data-lang="en"
+        data-loading="{{ gc.loading | default: 'lazy' }}"
         crossorigin="anonymous"
         async>
       </script>

--- a/_sass/_post.scss
+++ b/_sass/_post.scss
@@ -285,6 +285,23 @@ $po-line:    #ddd;
     }
   }
 
+  // ════════════════ GISCUS COMMENTS ════════════════
+  // Wrapper around the giscus iframe (which is themed separately via
+  // /assets/css/giscus-imessage.css). This just handles the section
+  // heading + spacing on the host page.
+  .post-comments {
+    margin-top: 2.5rem;
+    padding-top: 1.5rem;
+    border-top: 1px solid #eee;
+  }
+  .post-comments-title {
+    font-size: 1.15rem;
+    font-weight: 800;
+    letter-spacing: -0.01em;
+    margin: 0 0 1rem;
+    color: $po-ink;
+  }
+
   // ════════════════ LEGACY COMMENTS (iMessage-style) ════════════════
   // The old blog's comment thread, rendered as a chat: the author's
   // replies ("me") are blue bubbles on the right, everyone else's are

--- a/assets/css/giscus-imessage.css
+++ b/assets/css/giscus-imessage.css
@@ -1,0 +1,95 @@
+/* ============================================================================
+   giscus custom theme — "iMessage" bubbles for Random String of Words
+   ----------------------------------------------------------------------------
+   giscus renders inside its own iframe on giscus.app, so this file is loaded
+   *inside* that iframe (referenced via data-theme). We import giscus's official
+   light theme for a correct Primer base, then layer a chat-bubble look on top:
+     • everyone's comments  → grey bubbles, left-aligned
+     • the repo OWNER (you) → blue bubbles, right-aligned
+
+   HOW "your comments" are detected: GitHub tags each comment with an author
+   association and giscus renders it as a Primer `.Label` ("Owner"). Ordinary
+   visitors are association NONE and get no label, so `.gsc-comment:has(.Label)`
+   ≈ "your comments" on a personal blog. This is the one selector to VERIFY once
+   comments are live — if giscus names the owner marker differently, only the
+   two `:has(...)` blocks below need adjusting; the bubble look is independent.
+   ============================================================================ */
+
+@import url("https://giscus.app/themes/light.css");
+
+:root {
+  --rsow-accent: #2673da;   /* your bubble (blue) */
+  --rsow-them:   #e9e9eb;   /* their bubble (grey) */
+  --rsow-them-fg:#16181d;
+  --rsow-muted:  #97a1b2;
+}
+
+main { font-size: 14px; }
+
+/* ---- comment row ---------------------------------------------------------- */
+.gsc-comment {
+  margin: 0 0 0.5rem;
+}
+.gsc-comment > div,
+.gsc-comment-content {
+  border: 0 !important;
+  box-shadow: none !important;
+  background: transparent !important;
+}
+
+/* header (avatar · name · time) sits small above the bubble */
+.gsc-comment-header {
+  padding: 0 0.55rem 0.2rem !important;
+  background: transparent !important;
+  border: 0 !important;
+  font-size: 0.78rem;
+  color: var(--rsow-muted);
+}
+.gsc-comment-author-avatar img {
+  width: 22px !important;
+  height: 22px !important;
+}
+
+/* the message body → the bubble */
+.gsc-comment-content {
+  display: inline-block;
+  max-width: 82%;
+  padding: 0.6rem 0.9rem !important;
+  border-radius: 18px !important;
+  background: var(--rsow-them) !important;
+  color: var(--rsow-them-fg) !important;
+  line-height: 1.42;
+  border-bottom-left-radius: 5px !important;
+  box-shadow: 0 1px 1px rgba(0,0,0,0.06) !important;
+}
+.gsc-comment-content > *:first-child { margin-top: 0; }
+.gsc-comment-content > *:last-child  { margin-bottom: 0; }
+
+/* reactions / replies kept but understated */
+.gsc-reactions, .gsc-comment-reactions { padding-top: 0.35rem !important; }
+
+/* ---- OWNER (your) comments → blue, right-aligned -------------------------- */
+.gsc-comment:has(.Label) {
+  /* right-align the whole row */
+}
+.gsc-comment:has(.Label) .gsc-comment-header {
+  flex-direction: row-reverse !important;
+  text-align: right;
+}
+.gsc-comment:has(.Label) .gsc-comment-content {
+  margin-left: auto;
+  background: var(--rsow-accent) !important;
+  color: #fff !important;
+  border-bottom-left-radius: 18px !important;
+  border-bottom-right-radius: 5px !important;
+}
+.gsc-comment:has(.Label) .gsc-comment-content a { color: #fff; text-decoration: underline; }
+
+/* ---- the comment box (your reply editor) --------------------------------- */
+.gsc-comment-box {
+  border-radius: 14px !important;
+}
+.gsc-comment-box-textarea { border-radius: 10px !important; }
+
+/* tidy up the "Sign in with GitHub" prompt spacing */
+.gsc-comments > .gsc-header { margin-bottom: 0.5rem; }

--- a/assets/css/giscus-imessage.css
+++ b/assets/css/giscus-imessage.css
@@ -1,95 +1,88 @@
 /* ============================================================================
    giscus custom theme — "iMessage" bubbles for Random String of Words
    ----------------------------------------------------------------------------
-   giscus renders inside its own iframe on giscus.app, so this file is loaded
-   *inside* that iframe (referenced via data-theme). We import giscus's official
-   light theme for a correct Primer base, then layer a chat-bubble look on top:
-     • everyone's comments  → grey bubbles, left-aligned
-     • the repo OWNER (you) → blue bubbles, right-aligned
+   This is loaded INSIDE the giscus iframe (via data-theme). The official light
+   theme is inlined below (not @import'ed — @import gets dropped inside the
+   iframe, which left the base color variables undefined and everything with
+   black outlines). After the base we retint the accent to the site blue and
+   restyle posted comments as chat bubbles.
 
-   HOW "your comments" are detected: GitHub tags each comment with an author
-   association and giscus renders it as a Primer `.Label` ("Owner"). Ordinary
-   visitors are association NONE and get no label, so `.gsc-comment:has(.Label)`
-   ≈ "your comments" on a personal blog. This is the one selector to VERIFY once
-   comments are live — if giscus names the owner marker differently, only the
-   two `:has(...)` blocks below need adjusting; the bubble look is independent.
+   "Your" comments (repo OWNER) are detected via `.gsc-comment:has(.Label)` —
+   GitHub renders an author-association Label ("Owner") on them; ordinary
+   visitors are association NONE and get no label. If owner comments don't turn
+   blue/right once live, that's the one selector to adjust.
    ============================================================================ */
 
-@import url("https://giscus.app/themes/light.css");
+/* ---- giscus official light base (Primer tokens), inlined ------------------ */
+/*! MIT License
+ * Copyright (c) 2018 GitHub Inc.
+ * https://github.com/primer/primitives/blob/main/LICENSE
+ */main{--color-prettylights-syntax-comment:#6e7781;--color-prettylights-syntax-constant:#0550ae;--color-prettylights-syntax-entity:#8250df;--color-prettylights-syntax-storage-modifier-import:#24292f;--color-prettylights-syntax-entity-tag:#116329;--color-prettylights-syntax-keyword:#cf222e;--color-prettylights-syntax-string:#0a3069;--color-prettylights-syntax-variable:#953800;--color-prettylights-syntax-brackethighlighter-unmatched:#82071e;--color-prettylights-syntax-invalid-illegal-text:#f6f8fa;--color-prettylights-syntax-invalid-illegal-bg:#82071e;--color-prettylights-syntax-carriage-return-text:#f6f8fa;--color-prettylights-syntax-carriage-return-bg:#cf222e;--color-prettylights-syntax-string-regexp:#116329;--color-prettylights-syntax-markup-list:#3b2300;--color-prettylights-syntax-markup-heading:#0550ae;--color-prettylights-syntax-markup-italic:#24292f;--color-prettylights-syntax-markup-bold:#24292f;--color-prettylights-syntax-markup-deleted-text:#82071e;--color-prettylights-syntax-markup-deleted-bg:#ffebe9;--color-prettylights-syntax-markup-inserted-text:#116329;--color-prettylights-syntax-markup-inserted-bg:#dafbe1;--color-prettylights-syntax-markup-changed-text:#953800;--color-prettylights-syntax-markup-changed-bg:#ffd8b5;--color-prettylights-syntax-markup-ignored-text:#eaeef2;--color-prettylights-syntax-markup-ignored-bg:#0550ae;--color-prettylights-syntax-meta-diff-range:#8250df;--color-prettylights-syntax-brackethighlighter-angle:#57606a;--color-prettylights-syntax-sublimelinter-gutter-mark:#8c959f;--color-prettylights-syntax-constant-other-reference-link:#0a3069;--color-btn-text:#24292f;--color-btn-bg:#f6f8fa;--color-btn-border:#1f232826;--color-btn-shadow:0 1px 0 #1f23280a;--color-btn-inset-shadow:inset 0 1px 0 #ffffff40;--color-btn-hover-bg:#f3f4f6;--color-btn-hover-border:#1f232826;--color-btn-active-bg:#ebecf0;--color-btn-active-border:#1f232826;--color-btn-selected-bg:#eeeff2;--color-btn-primary-text:#fff;--color-btn-primary-bg:#1f883d;--color-btn-primary-border:#1f232826;--color-btn-primary-shadow:0 1px 0 #1f23281a;--color-btn-primary-inset-shadow:inset 0 1px 0 #ffffff08;--color-btn-primary-hover-bg:#1a7f37;--color-btn-primary-hover-border:#1f232826;--color-btn-primary-selected-bg:#187733;--color-btn-primary-selected-shadow:inset 0 1px 0 #002d1133;--color-btn-primary-disabled-text:#fffc;--color-btn-primary-disabled-bg:#94d3a2;--color-btn-primary-disabled-border:#1f232826;--color-action-list-item-default-hover-bg:#d0d7de52;--color-segmented-control-bg:#eaeef2;--color-segmented-control-button-bg:#fff;--color-segmented-control-button-selected-border:#8c959f;--color-fg-default:#1f2328;--color-fg-muted:#656d76;--color-fg-subtle:#6e7781;--color-canvas-default:#fff;--color-canvas-overlay:#fff;--color-canvas-inset:#f6f8fa;--color-canvas-subtle:#f6f8fa;--color-border-default:#d0d7de;--color-border-muted:#d8dee4;--color-neutral-muted:#afb8c133;--color-accent-fg:#0969da;--color-accent-emphasis:#0969da;--color-accent-muted:#54aeff66;--color-accent-subtle:#ddf4ff;--color-success-fg:#1a7f37;--color-attention-fg:#9a6700;--color-attention-muted:#d4a72c66;--color-attention-subtle:#fff8c5;--color-danger-fg:#d1242f;--color-danger-muted:#ff818266;--color-danger-subtle:#ffebe9;--color-primer-shadow-inset:inset 0 1px 0 #d0d7de33;--color-scale-gray-1:#eaeef2;--color-scale-blue-1:#b6e3ff;
 
-:root {
-  --rsow-accent: #2673da;   /* your bubble (blue) */
-  --rsow-them:   #e9e9eb;   /* their bubble (grey) */
-  --rsow-them-fg:#16181d;
-  --rsow-muted:  #97a1b2;
+  /*! Extensions from @primer/css/alerts/flash.scss */--color-social-reaction-bg-hover:var(--color-scale-gray-1);--color-social-reaction-bg-reacted-hover:var(--color-scale-blue-1)}main .pagination-loader-container{background-image:url(https://github.com/images/modules/pulls/progressive-disclosure-line.svg)}main .gsc-loading-image{background-image:url(https://github.githubassets.com/images/mona-loading-default.gif)}
+
+/* ---- Random String of Words overrides ------------------------------------ */
+main {
+  font-size: 14px;
+  /* GitHub green → site blue for the accent + the primary "Comment" button */
+  --color-accent-fg: #2673da;
+  --color-accent-emphasis: #2673da;
+  --color-btn-primary-bg: #2673da;
+  --color-btn-primary-hover-bg: #1f63c0;
+  --color-btn-primary-selected-bg: #1f63c0;
+  --color-btn-primary-disabled-bg: #9db8e6;
 }
 
-main { font-size: 14px; }
-
-/* ---- comment row ---------------------------------------------------------- */
-.gsc-comment {
-  margin: 0 0 0.5rem;
+/* Comment editor → clean white card with a soft grey border, like the posts */
+.gsc-comment-box {
+  background: #fff;
+  border: 1px solid #d7dbe0;
+  border-radius: 8px;
+  box-shadow: 0 1px 2px rgba(0,0,0,0.04);
 }
-.gsc-comment > div,
-.gsc-comment-content {
+.gsc-comment-box-textarea { border-radius: 6px; }
+.gsc-comment-box-tabs { background: #f6f8fa; }
+
+/* ---- posted comments → chat bubbles --------------------------------------- */
+.gsc-comment { margin: 0 0 0.55rem; }
+.gsc-comment > div {
   border: 0 !important;
   box-shadow: none !important;
   background: transparent !important;
+  padding: 0 !important;
 }
-
-/* header (avatar · name · time) sits small above the bubble */
 .gsc-comment-header {
   padding: 0 0.55rem 0.2rem !important;
   background: transparent !important;
   border: 0 !important;
   font-size: 0.78rem;
-  color: var(--rsow-muted);
 }
-.gsc-comment-author-avatar img {
-  width: 22px !important;
-  height: 22px !important;
-}
+.gsc-comment-author-avatar img { width: 22px !important; height: 22px !important; }
 
-/* the message body → the bubble */
+/* the message body is the bubble */
 .gsc-comment-content {
-  display: inline-block;
+  display: block;
+  width: fit-content;
   max-width: 82%;
+  margin-right: auto;                       /* left-aligned by default */
   padding: 0.6rem 0.9rem !important;
-  border-radius: 18px !important;
-  background: var(--rsow-them) !important;
-  color: var(--rsow-them-fg) !important;
+  border-radius: 18px 18px 18px 5px !important;
+  background: #e9e9eb !important;
+  color: #16181d !important;
   line-height: 1.42;
-  border-bottom-left-radius: 5px !important;
   box-shadow: 0 1px 1px rgba(0,0,0,0.06) !important;
 }
 .gsc-comment-content > *:first-child { margin-top: 0; }
 .gsc-comment-content > *:last-child  { margin-bottom: 0; }
-
-/* reactions / replies kept but understated */
 .gsc-reactions, .gsc-comment-reactions { padding-top: 0.35rem !important; }
 
-/* ---- OWNER (your) comments → blue, right-aligned -------------------------- */
-.gsc-comment:has(.Label) {
-  /* right-align the whole row */
-}
-.gsc-comment:has(.Label) .gsc-comment-header {
-  flex-direction: row-reverse !important;
-  text-align: right;
-}
+/* OWNER (you) → blue, right-aligned */
+.gsc-comment:has(.Label) .gsc-comment-header { flex-direction: row-reverse !important; text-align: right; }
 .gsc-comment:has(.Label) .gsc-comment-content {
   margin-left: auto;
-  background: var(--rsow-accent) !important;
+  margin-right: 0;
+  background: #2673da !important;
   color: #fff !important;
-  border-bottom-left-radius: 18px !important;
-  border-bottom-right-radius: 5px !important;
+  border-radius: 18px 18px 5px 18px !important;
 }
 .gsc-comment:has(.Label) .gsc-comment-content a { color: #fff; text-decoration: underline; }
-
-/* ---- the comment box (your reply editor) --------------------------------- */
-.gsc-comment-box {
-  border-radius: 14px !important;
-}
-.gsc-comment-box-textarea { border-radius: 10px !important; }
-
-/* tidy up the "Sign in with GitHub" prompt spacing */
-.gsc-comments > .gsc-header { margin-bottom: 0.5rem; }


### PR DESCRIPTION
## What

Adds live per-post comments backed by **GitHub Discussions** (giscus), styled to match the iMessage-style bubbles from the subluxation legacy comments. No backend, no token in the browser — visitors sign in with their own GitHub account and comment as themselves.

## How it works

- **`_layouts/post.html`** renders the giscus `<script>` after the article. It only appears when both `site.giscus.repo_id` and `category_id` are set **and** the post hasn't opted out with `allow_comments: false`.
- **`_config.yml`** has a `giscus:` block with placeholder IDs.
- **`assets/css/giscus-imessage.css`** is the custom giscus theme (loaded inside the giscus iframe): imports giscus's official light base, then restyles comments into chat bubbles — grey/left for visitors, **blue/right for the repo owner (you)**.
- **`.post-comments`** wrapper styles in `_post.scss`.

## ⚠️ To turn it on (GitHub steps I can't do)

1. Enable **Discussions**: repo Settings → Features → Discussions.
2. Install the **giscus GitHub App** on `palamedes/RSOW`: https://github.com/apps/giscus
3. Go to https://giscus.app, enter the repo, pick a category (e.g. *Comments*), and copy the **repo-id** and **category-id** it generates.
4. Paste those into the `giscus:` block in `_config.yml` (`repo_id` / `category_id`). Comments go live on next build.

Until step 4, nothing renders and posts build exactly as before (verified).

## ⚠️ One thing to verify live

The "**your** comments = blue/right" styling keys off GitHub's author-association marker (you show up as `OWNER`). The theme targets it with `.gsc-comment:has(.Label)`. I couldn't pixel-verify giscus's exact class without a live instance, so **if owner comments don't flip to blue/right once it's on, only that one selector needs a tweak** — the bubble look itself is independent and solid. Ordinary visitors are association `NONE` (no label) → grey/left.

## Notes

- Posts with `allow_comments: false` (e.g. the subluxation post) are suppressed, so that one keeps its hand-built legacy bubbles.
- Commenters need a GitHub account (fine for this audience; means fewer, higher-quality comments). Anonymous name/email comments would need the Cloudflare-Worker/Staticman route instead.
- Verified: gate on/off, the opt-out, the emitted script attributes, and the theme CSS serving 200. Could not verify actual rendered comments (needs the GitHub setup above).