### PR TITLE
giscus: right-align the header on your own comments

### DIFF
--- a/assets/css/giscus-imessage.css
+++ b/assets/css/giscus-imessage.css
@@ -88,6 +88,13 @@ main {
 .gsc-comment:has(.color-box-border-info) .gsc-comment-header {
   justify-content: flex-end;                /* your header on the right */
 }
+/* the avatar/name/time/pill live in a full-width flex row (.gsc-comment-author),
+   so right-pack them there — aligning the header alone doesn't move anything. */
+.gsc-comment:has(.color-box-border-info) .gsc-comment-author {
+  justify-content: flex-end !important;
+  width: 100%;
+  text-align: right;                        /* fallback if it isn't flex */
+}
 .gsc-comment:has(.color-box-border-info) .gsc-comment-content {
   margin: 0 0 0 auto;                       /* bubble floats right */
   background: #2673da !important;


### PR DESCRIPTION
Follow-up using the real giscus DOM you pasted.

The bubble already floats right for your (OWNER) comments, but the header — avatar, name, timestamp, "Owner" pill — stayed left. Reason: those items live in a **full-width `.gsc-comment-author` flex row** inside `.gsc-comment-header`, so aligning the header alone moves nothing (its one child fills the width). Fix right-packs the items *inside* `.gsc-comment-author` (`justify-content: flex-end`, with `text-align: right` as a non-flex fallback).

After this, your comments should be fully right-aligned (header **and** bubble), blue; visitors stay fully left, grey.

Deploy-gated: merge → Pages rebuild → hard-refresh. This one's based on your actual DOM, so it should be the last tweak.