### PR TITLE
Add AI notes to the six posts that were missing them

### DIFF
--- a/_posts/2026-07-16-flat-earthers-i-keep-hoping-theyre-just-trolls.md
+++ b/_posts/2026-07-16-flat-earthers-i-keep-hoping-theyre-just-trolls.md
@@ -8,6 +8,94 @@ categories:
 tags:
 description: "I keep hoping flat earthers are just trolls, because that's the easy version. The Earth is an oblate spheroid — we settled this a very long time ago. So this isn't an argument about the shape of the planet. It's an honest walk backward: from an innocent problem of scale, past all the evidence, to the exact moment ignorance stops being ignorance and becomes a choice not to know."
 excerpt: "I really do hope they're trolls, because trolling has a motive I can hold in my hand. The problem is I don't think all of them are joking. 'You're wrong' isn't an explanation, though, so I tried to work backward and figure out how a person actually gets here. Most don't start at stupid. They start at ignorant — at a problem of scale, an ant that thinks the car is flat — and then, somewhere after the evidence keeps landing, it curdles into something with a security system."
+ai_notes:
+  - quote: "water always finds its level"
+    rating: "Background"
+    note: >-
+      This slogan traces to Samuel Rowbotham's 1838 Bedford Level experiment on a
+      six-mile stretch of the Old Bedford River. In 1870 naturalist Alfred Russel
+      Wallace repeated it with proper controls for atmospheric refraction and
+      measured the curvature Rowbotham had missed.
+    sources:
+      - title: "Bedford Level Experiment (1838 and 1870 observations)"
+        url: "https://en.wikipedia.org/wiki/Bedford_Level_experiment"
+  - quote: "We nailed this down a very, very long time ago"
+    rating: "True"
+    note: >-
+      Accurate. Earth is an oblate spheroid: NASA lists an equatorial diameter of
+      12,756 km against a polar diameter of 12,714 km, a flattening of about
+      1/298. The bulge comes from rotation, not from anything controversial.
+    sources:
+      - title: "NASA NSSDCA — Earth Fact Sheet"
+        url: "https://nssdc.gsfc.nasa.gov/planetary/factsheet/earthfact.html"
+  - quote: "a ball 8,000 miles across"
+    rating: "Mostly True"
+    note: >-
+      Close enough as a round number. Earth's mean diameter is about 7,918 miles
+      (12,742 km), roughly 7,926 miles at the equator and 7,900 miles pole to
+      pole.
+    sources:
+      - title: "NASA NSSDCA — Earth Fact Sheet"
+        url: "https://nssdc.gsfc.nasa.gov/planetary/factsheet/earthfact.html"
+  - quote: "watch the horizon visibly bend around your sneakers"
+    rating: "Context"
+    note: >-
+      The geometry is on the author's side here. From an eye height of about six
+      feet the horizon sits only around three miles away, and the surface drops
+      roughly eight inches over the first mile, which is well inside what heat
+      haze and refraction can hide.
+    sources:
+      - title: "Horizon — distance to the horizon and geometrical formulas"
+        url: "https://en.wikipedia.org/wiki/Horizon"
+  - quote: "Shadows measured the circumference of the Earth before Rome was Rome"
+    rating: "Needs Context"
+    note: >-
+      The experiment is real, the timeline is loose. Eratosthenes compared noon
+      shadows at Alexandria and Syene around 240 BCE and got 250,000 stadia,
+      within a few percent of the modern 40,008 km. Rome by then was already a
+      major republic, fresh off the First Punic War.
+    sources:
+      - title: "Britannica — Eratosthenes"
+        url: "https://www.britannica.com/biography/Eratosthenes"
+  - quote: "Ships vanish hull-first over the horizon"
+    rating: "True"
+    note: >-
+      Accurate, and old. Aristotle listed it in De Caelo around 350 BCE alongside
+      the round shadow Earth casts on the Moon during a lunar eclipse and the way
+      the visible stars change as you travel north or south.
+    sources:
+      - title: "Internet Classics Archive — Aristotle, On the Heavens, Book II"
+        url: "http://classics.mit.edu/Aristotle/heavens.2.ii.html"
+  - quote: "Nobody accidentally flies into the ice wall"
+    rating: "Background"
+    note: >-
+      The ice wall comes from Rowbotham's 1865 model, which put a flat disc
+      centered on the North Pole and ringed by a wall of ice. Antarctica has been
+      circumnavigated and continuously occupied since; 12 nations signed the
+      Antarctic Treaty in 1959 and it now has well over 50 parties.
+    sources:
+      - title: "U.S. Department of State — The Antarctic Treaty (1959)"
+        url: "https://www.state.gov/antarctic-treaty/"
+  - quote: "Satellites work. GPS works"
+    rating: "True"
+    note: >-
+      The U.S. Space Force flies 31 operational GPS satellites in six orbital
+      planes at about 12,550 miles altitude. The arrangement exists so at least
+      four are visible from any point on a sphere, and the math it runs on assumes
+      exactly that shape.
+    sources:
+      - title: "GPS.gov — Space Segment"
+        url: "https://www.gps.gov/space-segment"
+  - quote: "Some are lonely and love finally belonging"
+    rating: "Context"
+    note: >-
+      A 2018 YouGov survey of 8,215 U.S. adults found 84% say Earth is round and
+      2% say it is flat, with the rest unsure or doubting. Among the flat-Earth
+      respondents, 52% described themselves as very religious against 20% of
+      Americans overall.
+    sources:
+      - title: "YouGov — Most flat earthers consider themselves very religious (2018)"
+        url: "https://today.yougov.com/society/articles/20510-most-flat-earthers-consider-themselves-religious"
 ---
 
 I hope they're trolls.

--- a/_posts/2026-07-18-merit-isnt-racist.md
+++ b/_posts/2026-07-18-merit-isnt-racist.md
@@ -8,6 +8,89 @@ categories:
 tags:
 description: "DEI is marketed as fairness while it abandons the most basic principle of fairness there is: judge the individual, not the category. Intentions don't change the act — if you hire or reject someone because of the color of their skin, that's racism, no matter how much corporate jargon you wrap around it. Merit isn't racist. Standards aren't racist. Racism is racist."
 excerpt: "DEI is racism with a marketing department — that's the part nobody is supposed to say out loud. We're told judging people by skin color is evil, unless the people doing the judging have good intentions and put 'equity' in a PowerPoint. But intentions don't change the act. You don't defeat racism by changing which race gets discriminated against. You defeat it by refusing to discriminate."
+ai_notes:
+  - quote: "put \"equity\" in a PowerPoint"
+    rating: "Context"
+    note: >-
+      Title VII of the Civil Rights Act of 1964 bars employment discrimination
+      because of race, with no exception for good intentions. Section 703(j) goes
+      further and states that nothing in the title requires preferential treatment
+      to correct a racial imbalance in a workforce.
+    sources:
+      - title: "EEOC — Title VII of the Civil Rights Act of 1964 (full text)"
+        url: "https://www.eeoc.gov/statutes/title-vii-civil-rights-act-1964"
+  - quote: "If you refuse to hire someone because of the color of his skin"
+    rating: "True"
+    note: >-
+      Settled law. In McDonald v. Santa Fe Trail Transportation Co. (1976) the
+      Supreme Court held that Title VII protects white employees on precisely the
+      same terms as everyone else, and that its terms are not limited to
+      discrimination against members of any particular race.
+    sources:
+      - title: "Justia — McDonald v. Santa Fe Trail Transportation Co., 427 U.S. 273 (1976)"
+        url: "https://supreme.justia.com/cases/federal/us/427/273/"
+  - quote: "is a cowardly term designed to make one flavor"
+    rating: "True"
+    note: >-
+      The courts recently agreed on the substance. In Ames v. Ohio Department of
+      Youth Services, decided unanimously on June 5, 2025, the Supreme Court threw
+      out the rule requiring majority-group plaintiffs to clear an extra
+      background circumstances hurdle that minority plaintiffs never faced.
+    sources:
+      - title: "Supreme Court of the United States — Ames v. Ohio Dept. of Youth Servs. (2025)"
+        url: "https://www.supremecourt.gov/opinions/24pdf/23-1039_c0n2.pdf"
+  - quote: "scholarships, contracts, and admissions policies where race matters enormously"
+    rating: "Context"
+    note: >-
+      On admissions specifically, this changed in 2023. Students for Fair
+      Admissions v. Harvard held race-conscious admissions unconstitutional,
+      though the Court carved out room for essays describing how race affected an
+      applicant personally, and expressly left the military academies aside.
+    sources:
+      - title: "Supreme Court of the United States — SFFA v. President and Fellows of Harvard College (2023)"
+        url: "https://www.supremecourt.gov/opinions/22pdf/20-1199_hgdj.pdf"
+  - quote: "It quietly assumes certain groups can't succeed under neutral standards"
+    rating: "Context"
+    note: >-
+      This stigma argument has a long paper trail on the Court. Justice Thomas has
+      pressed it since his Grutter dissent in 2003 and again at length in his 2023
+      SFFA concurrence, arguing racial preferences taint the accomplishments of
+      the people they are meant to help.
+    sources:
+      - title: "Supreme Court of the United States — SFFA v. Harvard (2023), Thomas, J., concurring"
+        url: "https://www.supremecourt.gov/opinions/22pdf/20-1199_hgdj.pdf"
+  - quote: "The defenders of DEI usually respond by saying merit itself is biased"
+    rating: "Context"
+    note: >-
+      The best-known evidence for that claim is a 2003 field experiment by
+      Bertrand and Mullainathan, which sent about 5,000 fictitious resumes to
+      Boston and Chicago job ads. Identical resumes with white-sounding names drew
+      roughly 50% more callbacks than those with Black-sounding names.
+    sources:
+      - title: "NBER Working Paper 9873 — Are Emily and Greg More Employable than Lakisha and Jamal?"
+        url: "https://www.nber.org/papers/w9873"
+  - quote: "A person's skin color should neither help them nor hurt them"
+    rating: "Background"
+    note: >-
+      This echoes the framing of the 1964 Civil Rights Act, signed July 2, 1964,
+      which outlawed discrimination based on race, color, religion, sex, or
+      national origin in employment and public accommodations without reference to
+      which group was affected.
+    sources:
+      - title: "National Archives — Civil Rights Act of 1964"
+        url: "https://www.archives.gov/milestone-documents/civil-rights-act"
+  - quote: "Help disadvantaged people based on actual disadvantage"
+    rating: "Context"
+    note: >-
+      California ran this experiment. Proposition 209 passed 54% to 46% in
+      November 1996, barring racial preferences in state hiring, contracting, and
+      admissions; the University of California shifted toward socioeconomic and
+      outreach-based criteria, and voters declined to repeal the ban in 2020.
+    sources:
+      - title: "California Legislative Analyst's Office — Proposition 209 (1996)"
+        url: "https://lao.ca.gov/ballot/1996/prop209_11_1996.html"
+      - title: "University of California — Research and Analyses on the Impact of Proposition 209"
+        url: "https://www.ucop.edu/academic-affairs/prop-209/index.html"
 ---
 
 DEI is racism with a marketing department. That's the part nobody is supposed to say out loud.

--- a/_posts/2026-07-20-far-right-does-not-mean-what-you-think-it-means.md
+++ b/_posts/2026-07-20-far-right-does-not-mean-what-you-think-it-means.md
@@ -8,6 +8,77 @@ categories:
 tags:
 description: "\"Hitler was right wing\" is a word game, not a history lesson. The phrase 'far right' is doing double duty — the old European meaning (nationalism, racial hierarchy, dictatorship) versus the modern American meaning (lower taxes, gun rights, limited government). Swap the definitions halfway through and you can 'prove' conservatives are Nazis. Same word, different political tradition."
 excerpt: "People love to post 'Hitler was right wing' and then turn the comments off — because nothing says intellectual confidence like barricading the door so nobody can question you. The trick is that 'far right' means one thing when historians describe the Nazis and something completely different when Americans describe Republicans. Use both meanings in the same argument and hope nobody notices the definition changed halfway through."
+ai_notes:
+  - quote: "they are generally using an old European political definition"
+    rating: "True"
+    note: >-
+      The left-right axis is literally a seating chart. In the French National
+      Assembly of 1789, deputies who backed the king and the old order sat to the
+      president's right and supporters of the revolution to his left. Every later
+      meaning is borrowed from that room.
+    sources:
+      - title: "Left-right political spectrum — origin in the 1789 National Assembly"
+        url: "https://en.wikipedia.org/wiki/Left%E2%80%93right_political_spectrum"
+  - quote: "crushed political opposition"
+    rating: "True"
+    note: >-
+      Accurate, and it happened fast. The Enabling Act of March 23, 1933 let
+      Hitler's cabinet issue laws without the Reichstag, and the Law against the
+      Founding of New Parties on July 14, 1933 made the NSDAP the only legal party
+      in Germany.
+    sources:
+      - title: "USHMM Holocaust Encyclopedia — The Enabling Act"
+        url: "https://encyclopedia.ushmm.org/content/en/article/the-enabling-act"
+      - title: "USHMM Holocaust Encyclopedia — Law against the Founding of New Parties"
+        url: "https://encyclopedia.ushmm.org/content/en/article/law-against-the-founding-of-new-parties"
+  - quote: "abolished independent unions, directed industry"
+    rating: "True"
+    note: >-
+      Accurate on unions. On May 2, 1933, one day after co-opting the May Day
+      holiday, the regime raided and dissolved Germany's free trade unions and
+      replaced them with the state-run German Labor Front.
+    sources:
+      - title: "USHMM Holocaust Encyclopedia — 1933: Key Dates"
+        url: "https://encyclopedia.ushmm.org/content/en/article/1933-key-dates"
+  - quote: "confiscated property, regulated private life"
+    rating: "Needs Context"
+    note: >-
+      True of Jewish and dissident property, which was seized outright. The wider
+      economic picture is less tidy: economist Germa Bel documents that in the
+      mid-1930s the regime sold state-owned firms in steel, banking, shipping, and
+      railways back into private hands, against the era's trend.
+    sources:
+      - title: "Economic History Review — Bel, Against the mainstream: Nazi privatization in 1930s Germany (2010)"
+        url: "https://onlinelibrary.wiley.com/doi/abs/10.1111/j.1468-0289.2009.00473.x"
+  - quote: "North Korea calls itself the Democratic People's Republic of Korea"
+    rating: "True"
+    note: >-
+      Accurate. The DPRK adopted that name at its founding on September 9, 1948.
+      Freedom House has for years scored it at the bottom of its global rankings,
+      and its elections offer a single approved candidate per seat.
+    sources:
+      - title: "CIA World Factbook — Korea, North (government and country name)"
+        url: "https://www.cia.gov/the-world-factbook/countries/korea-north/"
+  - quote: "They opposed Marxist international socialism"
+    rating: "True"
+    note: >-
+      Accurate. The Communist Party of Germany was suppressed after the Reichstag
+      fire of February 1933 and its deputies arrested, and the Night of the Long
+      Knives in June 1934 also destroyed the party's own anti-capitalist Strasser
+      wing.
+    sources:
+      - title: "USHMM Holocaust Encyclopedia — 1933: Key Dates"
+        url: "https://encyclopedia.ushmm.org/content/en/article/1933-key-dates"
+  - quote: "one built camps and a one-party police state"
+    rating: "True"
+    note: >-
+      Accurate. Dachau, the first regular Nazi concentration camp, opened outside
+      Munich in March 1933, receiving its first prisoners on March 22, weeks after
+      Hitler took office. It held political prisoners long before it held anyone
+      else.
+    sources:
+      - title: "USHMM Holocaust Encyclopedia — Dachau"
+        url: "https://encyclopedia.ushmm.org/content/en/article/dachau"
 ---
 
 I keep seeing people on the left proudly post some variation of:

--- a/_posts/2026-07-23-the-communist-manifesto-is-not-about-community.md
+++ b/_posts/2026-07-23-the-communist-manifesto-is-not-about-community.md
@@ -8,6 +8,127 @@ categories:
 tags:
 description: "Communism and community share four letters and nothing else. The Communist Manifesto isn't a warm story about neighbors sharing — it's a revolutionary program with an actual to-do list: abolish private property, seize the banks, confiscate the land, and hand the whole economy to one authority that's somehow supposed to give the power back afterward. It never does."
 excerpt: "People sell the Communist Manifesto like it's a children's book about putting all the toys in one box. It isn't. It's a blueprint for power — overthrow, confiscation, centralization — and the state at the center of it doesn't show up with a casserole. It shows up with a list of what you own."
+ai_notes:
+  - quote: "the resemblance stops at the first four letters"
+    rating: "Background"
+    note: >-
+      Both words descend from the Latin communis, meaning shared or common, but
+      they part company in the 1840s. Communism entered English as the name of a
+      specific political movement, and the Manifesto was published in London in
+      February 1848, weeks before revolutions broke out across Europe.
+    sources:
+      - title: "Marxists Internet Archive — Manifesto of the Communist Party (1848), full text"
+        url: "https://www.marxists.org/archive/marx/works/1848/communist-manifesto/"
+  - quote: "Abolition of private property"
+    rating: "True"
+    note: >-
+      Quoted correctly. Chapter II states that the theory of the Communists may be
+      summed up in the single sentence: abolition of private property. The chapter
+      then argues the target is bourgeois property specifically, not all personal
+      possessions.
+    sources:
+      - title: "Marxists Internet Archive — Manifesto, Chapter II: Proletarians and Communists"
+        url: "https://www.marxists.org/archive/marx/works/1848/communist-manifesto/ch02.htm"
+  - quote: "Shuffle populations around between city and country as needed"
+    rating: "True"
+    note: >-
+      A fair paraphrase of the ten measures listed at the end of Chapter II. Point
+      nine calls for combining agriculture with manufacturing industries and the
+      gradual abolition of the distinction between town and country by a more
+      equable distribution of the population.
+    sources:
+      - title: "Marxists Internet Archive — Manifesto, Chapter II (the ten measures)"
+        url: "https://www.marxists.org/archive/marx/works/1848/communist-manifesto/ch02.htm"
+  - quote: "despotic inroads"
+    rating: "True"
+    note: >-
+      Verbatim. The text says the proletariat will use its political supremacy to
+      wrest all capital from the bourgeoisie by means of despotic inroads on the
+      rights of property, and describes those measures as economically
+      insufficient and untenable on their own.
+    sources:
+      - title: "Marxists Internet Archive — Manifesto, Chapter II"
+        url: "https://www.marxists.org/archive/marx/works/1848/communist-manifesto/ch02.htm"
+  - quote: "That distinction exists in the theory"
+    rating: "Accurate"
+    note: >-
+      The text does draw it explicitly. Chapter II answers the charge directly,
+      saying communism deprives no one of the power to appropriate the products of
+      society and abolishes only the power to subjugate the labour of others by
+      means of such appropriation.
+    sources:
+      - title: "Marxists Internet Archive — Manifesto, Chapter II"
+        url: "https://www.marxists.org/archive/marx/works/1848/communist-manifesto/ch02.htm"
+  - quote: "the worker gets just enough to survive"
+    rating: "Context"
+    note: >-
+      This is the subsistence-wage idea Marx inherited from Ricardo and later
+      formalized as surplus value in Capital, volume one, published in 1867. Most
+      modern economists abandoned the underlying labor theory of value after the
+      1870s marginal revolution.
+    sources:
+      - title: "Marxists Internet Archive — Capital, Volume I (1867)"
+        url: "https://www.marxists.org/archive/marx/works/1867-c1/"
+  - quote: "That was Hayek's whole point"
+    rating: "True"
+    note: >-
+      Accurately stated. Hayek made the argument in The Use of Knowledge in
+      Society, published in the American Economic Review in September 1945. Ludwig
+      von Mises had raised the related economic calculation problem in 1920,
+      arguing planners without prices cannot compare alternatives.
+    sources:
+      - title: "Econlib — F. A. Hayek, The Use of Knowledge in Society (1945)"
+        url: "https://www.econlib.org/library/Essays/hykKnw.html"
+  - quote: "Marx figured that once the classes were gone"
+    rating: "Needs Context"
+    note: >-
+      The famous phrasing is Engels', not Marx's. In Anti-Duhring (1878) Engels
+      wrote that the state is not abolished, it withers away. Lenin built State
+      and Revolution (1917) around the idea, then presided over a state that grew
+      rather than faded.
+    sources:
+      - title: "Marxists Internet Archive — Engels, Anti-Duhring (1878)"
+        url: "https://www.marxists.org/archive/marx/works/1877/anti-duhring/"
+  - quote: "Stalin's forced collectivization seized the farmland"
+    rating: "True"
+    note: >-
+      Accurate. Collectivization began in 1929 and the resulting famine of 1932-33
+      killed roughly five million across the USSR, with common estimates of about
+      3.5 to 4 million deaths in Ukraine alone, the event now known as the
+      Holodomor.
+    sources:
+      - title: "Britannica — Holodomor"
+        url: "https://www.britannica.com/event/Holodomor"
+  - quote: "Somewhere around 30 million people starved"
+    rating: "Partly True"
+    note: >-
+      Within the accepted range, toward its lower end. Estimates for the Great
+      Leap Forward famine of 1959-61 run from roughly 15 million to 45 million
+      excess deaths; Yang Jisheng put it at 36 million and Frank Dikotter at 45
+      million.
+    sources:
+      - title: "Association for Asian Studies — China's Great Leap Forward"
+        url: "https://www.asianstudies.org/publications/eaa/archives/chinas-great-leap-forward/"
+  - quote: "pulling something like 800 million people out of extreme poverty"
+    rating: "True"
+    note: >-
+      Accurate and correctly attributed. The World Bank reports that since reforms
+      began in 1978, nearly 800 million Chinese have risen above the extreme
+      poverty line, accounting for close to three-quarters of global poverty
+      reduction over that period.
+    sources:
+      - title: "World Bank — Lifting 800 Million People Out of Poverty (2022)"
+        url: "https://www.worldbank.org/en/news/press-release/2022/04/01/lifting-800-million-people-out-of-poverty-new-report-looks-at-lessons-from-china-s-experience"
+  - quote: "all of history is basically class struggle"
+    rating: "Accurate"
+    note: >-
+      That is the Manifesto's opening claim: the history of all hitherto existing
+      society is the history of class struggles. Engels added a footnote in the
+      1888 English edition narrowing it to written history, after research on
+      preliterate communal societies.
+    sources:
+      - title: "Marxists Internet Archive — Manifesto, Chapter I: Bourgeois and Proletarians"
+        url: "https://www.marxists.org/archive/marx/works/1848/communist-manifesto/ch01.htm"
 ---
 
 Communism is not about community.

--- a/_posts/2026-08-08-the-meltdown-was-the-point.md
+++ b/_posts/2026-08-08-the-meltdown-was-the-point.md
@@ -8,6 +8,66 @@ categories:
 tags:
 description: "A viral video of a grown adult melting down during an arrest — screaming to be called 'she' — is easy to laugh at. But the tantrum wasn't a glitch. It was the finished product of a culture that teaches people distress is leverage, fragility is status, and reality is supposed to reorganize itself around their feelings. Then the real world showed up wearing a badge."
 excerpt: "He learned that crying louder gives you power over the room — that the second the tears start, everyone else is supposed to soften up and rearrange reality around his feelings. It worked on teachers, on HR, on social media. Then he met police officers who just needed him to stop causing a scene. The meltdown didn't strengthen his case. It destroyed it."
+ai_notes:
+  - quote: "demanding to be called"
+    rating: "Background"
+    note: >-
+      For scale: the Williams Institute at UCLA estimated in August 2025 that
+      about 2.8 million people aged 13 and older in the United States identify as
+      transgender, roughly 1.0% of that age group, based on CDC survey data.
+    sources:
+      - title: "Williams Institute, UCLA School of Law — Transgender population estimates (2025)"
+        url: "https://williamsinstitute.law.ucla.edu/press/trans-pop-estimates-press-release/"
+  - quote: "It feels like a mental health crisis we've collectively decided to indulge"
+    rating: "Context"
+    note: >-
+      On the clinical question specifically: the DSM-5-TR diagnoses gender
+      dysphoria, defined by clinically significant distress, while stating that
+      gender nonconformity is not itself a mental disorder. The WHO's ICD-11 moved
+      the condition out of its mental-disorders chapter entirely.
+    sources:
+      - title: "American Psychiatric Association — What Is Gender Dysphoria?"
+        url: "https://www.psychiatry.org/patients-families/gender-dysphoria/what-is-gender-dysphoria"
+  - quote: "They weren't there to explore his feelings"
+    rating: "Context"
+    note: >-
+      Pronoun rules for officers do exist, but mostly in custody settings rather
+      than street encounters. California's Transgender Respect, Agency, and
+      Dignity Act, signed September 2020, requires state corrections staff to use
+      an incarcerated person's stated pronouns and honorifics.
+    sources:
+      - title: "California Legislative Information — SB 132 (2020), Penal Code 2605-2606"
+        url: "https://leginfo.legislature.ca.gov/faces/billNavClient.xhtml?bill_id=201920200SB132"
+  - quote: "refusing lawful instructions and escalating a public disturbance"
+    rating: "Context"
+    note: >-
+      Every state criminalizes this conduct in some form. In North Carolina,
+      willfully resisting, delaying, or obstructing a public officer performing an
+      official duty is a Class 2 misdemeanor under G.S. 14-223, with felony
+      enhancements if it causes an officer serious injury.
+    sources:
+      - title: "North Carolina General Assembly — G.S. 14-223, Resisting officers"
+        url: "https://www.ncleg.gov/enactedlegislation/statutes/html/bysection/chapter_14/gs_14-223.html"
+  - quote: "He was taught the world splits neatly into victims and oppressors"
+    rating: "Context"
+    note: >-
+      There is research on the incentive the author describes. A 2021 Journal of
+      Personality and Social Psychology paper by Ok and colleagues found that
+      frequent signaling of virtuous victimhood correlated with Dark Triad traits
+      and predicted willingness to extract resources from others.
+    sources:
+      - title: "PubMed — Ok et al., Signaling virtuous victimhood as indicators of Dark Triad personalities (2021)"
+        url: "https://pubmed.ncbi.nlm.nih.gov/32614222/"
+  - quote: "an entire ideological machine convinced him this would work"
+    rating: "Context"
+    note: >-
+      Departments do train for encounters like this one. The Crisis Intervention
+      Team model, built in Memphis in 1988 with the local NAMI chapter and two
+      universities, puts volunteer officers through 40 hours of de-escalation
+      training and has since spread nationally and internationally.
+    sources:
+      - title: "CIT Center, University of Memphis — About CIT"
+        url: "https://cit.memphis.edu/aboutCIT.php"
 ---
 
 You've probably seen the video by now.

--- a/_posts/2026-08-18-the-camera-isnt-the-problem-the-database-is.md
+++ b/_posts/2026-08-18-the-camera-isnt-the-problem-the-database-is.md
@@ -9,6 +9,106 @@ categories:
 tags:
 description: "Yes, your license plate is visible in public. That was never the argument. Flock isn't replacing the cop sitting beside the road — it's building a searchable historical record of where millions of people have been, almost none of whom are suspected of anything. A former cop on Carpenter, Chatrie, Baltimore's spy plane, and why 'but you're in public' misses the point entirely."
 excerpt: "One cop watching you drive down Main Street isn't the same thing as every cop in the country being able to ask a database everywhere you've driven for the last three months. Those aren't remotely equivalent capabilities. Useful does not mean constitutionally unlimited."
+ai_notes:
+  - quote: "Your license plate is visible in public, therefore you have no expectation of privacy"
+    rating: "Needs Context"
+    note: >-
+      This is the plain-view and third-party reasoning, and courts increasingly
+      treat it as incomplete. In Chatrie (2026) the Supreme Court rejected the
+      government's third-party argument for location data, holding it is not truly
+      shared in the ordinary sense of the word.
+    sources:
+      - title: "Supreme Court of the United States — Chatrie v. United States (2026)"
+        url: "https://www.supremecourt.gov/opinions/25pdf/25-112_0am4.pdf"
+  - quote: "It's creating a gigantic, searchable historical record"
+    rating: "True"
+    note: >-
+      Accurate as to scale. Flock Safety has grown to roughly 5,000 contracting
+      communities and well over 100,000 cameras across nearly every state, though
+      more than 50 agencies canceled, suspended, or rejected contracts during 2026
+      amid privacy objections.
+    sources:
+      - title: "Flock Safety — company overview and deployment figures"
+        url: "https://en.wikipedia.org/wiki/Flock_Safety"
+  - quote: "The Supreme Court already recognized this problem with cellphone location data"
+    rating: "True"
+    note: >-
+      Correct. Carpenter v. United States (2018) held 5-4 that obtaining seven
+      days of cell-site location records is a Fourth Amendment search, reasoning
+      that individuals have a reasonable expectation of privacy in the whole of
+      their physical movements.
+    sources:
+      - title: "Supreme Court of the United States — Carpenter v. United States, 585 U.S. 296 (2018)"
+        url: "https://www.supremecourt.gov/opinions/17pdf/16-402_h315.pdf"
+  - quote: "Police obtained Google's historical location data during a robbery investigation"
+    rating: "True"
+    note: >-
+      Accurate. Chatrie v. United States, decided June 29, 2026, arose from a 2019
+      credit union robbery in Midlothian, Virginia and a geofence warrant covering
+      a 150-meter radius. Justice Kagan wrote for the Court; Justices Alito,
+      Thomas, and Barrett dissented in whole or part.
+    sources:
+      - title: "Supreme Court of the United States — Chatrie v. United States, 609 U.S. ___ (2026)"
+        url: "https://www.supremecourt.gov/opinions/25pdf/25-112_0am4.pdf"
+  - quote: "Police no longer necessarily have to decide to follow you before you do something"
+    rating: "True"
+    note: >-
+      This tracks the opinion's own language. The Court noted Location History
+      lets police reconstruct people's comings and goings retrospectively and with
+      no real effort, and rejected the argument that a short window of data escapes
+      the Fourth Amendment.
+    sources:
+      - title: "Supreme Court of the United States — Chatrie v. United States (2026), syllabus"
+        url: "https://www.supremecourt.gov/opinions/25pdf/25-112_0am4.pdf"
+  - quote: "a federal district court recently upheld Norfolk, Virginia's Flock system"
+    rating: "True"
+    note: >-
+      That is Schmidt v. City of Norfolk. In early 2026 the Eastern District of
+      Virginia granted the city summary judgment over its roughly 170 cameras,
+      finding insufficient evidence the network captured enough images to
+      reconstruct the whole of anyone's movements.
+    sources:
+      - title: "Institute for Justice — Hampton Roads residents will appeal Norfolk license plate reader decision"
+        url: "https://ij.org/press-release/hampton-roads-residents-will-appeal-court-decision-upholding-norfolks-license-plate-reader-surveillance/"
+  - quote: "Baltimore once operated an aerial surveillance system"
+    rating: "True"
+    note: >-
+      That is Leaders of a Beautiful Struggle v. Baltimore Police Department, 2
+      F.4th 330 (4th Cir. 2021) (en banc). The AIR program photographed about 90%
+      of the city for roughly 12 daylight hours a day and stored images for 45
+      days; the court held accessing that data was a search.
+    sources:
+      - title: "Justia — Leaders of a Beautiful Struggle v. Baltimore Police Dept., No. 20-1495 (4th Cir. 2021)"
+        url: "https://law.justia.com/cases/federal/appellate-courts/ca4/20-1495/20-1495-2021-06-24.html"
+  - quote: "The Fourth Amendment was written in 1791"
+    rating: "Mostly True"
+    note: >-
+      Close. James Madison introduced what became the Fourth Amendment in 1789 and
+      Congress approved it that September; ratification finished on December 15,
+      1791, when Virginia became the eleventh state to adopt the Bill of Rights.
+    sources:
+      - title: "National Archives — The Bill of Rights (1791)"
+        url: "https://www.archives.gov/milestone-documents/bill-of-rights"
+  - quote: "North Carolina law currently allows ALPR data to be retained for up to"
+    rating: "True"
+    note: >-
+      Accurate. G.S. 20-183.32 bars preserving captured plate data more than 90
+      days, with exceptions for a written preservation request or a search
+      warrant. Preserved data is held about a year unless another request resets
+      the clock.
+    sources:
+      - title: "North Carolina General Assembly — Chapter 20, Article 3D, Automatic License Plate Reader Systems"
+        url: "https://ncleg.gov/EnactedLegislation/Statutes/HTML/ByArticle/Chapter_20/Article_3D.html"
+  - quote: "If you can afford the machine gun"
+    rating: "Context"
+    note: >-
+      Current federal law is narrower than that. The National Firearms Act of 1934
+      taxes and registers machine guns, and 18 U.S.C. 922(o), added by the Hughes
+      Amendment in 1986, bars civilian possession of any made after May 19, 1986,
+      leaving only a frozen pre-1986 pool.
+    sources:
+      - title: "U.S. House, Office of the Law Revision Counsel — 18 U.S.C. 922"
+        url: "https://uscode.house.gov/view.xhtml?req=granuleid:USC-prelim-title18-section922&num=0&edition=prelim"
 ---
 
 I've been thinking about Flock cameras and the Fourth Amendment, and the deeper I dig into it, the less comfortable I am with them. Before somebody starts with, **“Your license plate is visible in public, therefore you have no expectation of privacy,”** yes, I know. That's true. It's also completely missing the fucking point.


### PR DESCRIPTION
Backfills `ai_notes:` front matter for the six posts that didn't have it — 52 notes across 54 sources. No prose changed.

Every anchor phrase verified to resolve exactly once in the rendered HTML, and all source URLs checked for dead links.