### PR TITLE
Record the XYLD → SCHD decision as in-flight

### DIFF
--- a/_data/drip.json
+++ b/_data/drip.json
@@ -75,8 +75,8 @@
       "why": "Not a dividend-income play and doesn't fit the strategy cleanly, but the gain has held at about +34% for two straight quarters and it keeps paying monthly.",
       "risk": "Watch. Do not add. Consider selling if the gain erodes below $200 or a better use of capital emerges. It has now survived three quarterly reviews on inertia — decide it or sell it." },
     { "ticker": "XYLD", "name": "Global X S&P 500 Covered Call ETF",      "tier": "hold",    "role": "Covered call (S&P 500)", "monthly": true, "value": 1052.15, "pct": 4.35, "costBasis": 1041.47, "gain": 10.68, "gainPct": 1.02, "annualIncome": 116, "targetYield": "~11%", "shares": 25.268, "price": 41.64, "avgCost": 41.22, "todayPct": -0.03, "todayDollar": -0.26,
-      "why": "The strongest covered-call base (S&P 500). Nudged into the green for the first time. Hold, do not add.",
-      "risk": "" },
+      "why": "The strongest covered-call base (S&P 500) — but redundant next to JEPI, which does the same job with a less punishing structure. Sold on Aug 20, 2026 while the gain was still only $10.68 and the exit was effectively free. Proceeds go to SCHD.",
+      "risk": "Sale decided and in flight — settlement pending, so it still appears here as held." },
     { "ticker": "KO",   "name": "Coca-Cola",                               "tier": "hold",    "role": "Dividend aristocrat", "monthly": false, "value": 1025.27, "pct": 4.23, "costBasis": 595.27, "gain": 430.00, "gainPct": 72.23, "annualIncome": 29, "targetYield": "~2.8%", "shares": 11.411, "price": 89.85, "avgCost": 52.17, "todayPct": 1.15, "todayDollar": 11.75,
       "why": "60+ year dividend grower. Never cuts. Boring perfection — and it just crossed $1,000 on nothing but price growth and reinvested dividends.",
       "risk": "" },
@@ -95,6 +95,25 @@
   ],
 
   "cash": { "ticker": "SPAXX", "name": "Fidelity Government Money Market", "value": 3.72 },
+
+  "pending": {
+    "date": "2026-08-20",
+    "ticker": "XYLD",
+    "into": "SCHD",
+    "amount": 1052.15,
+    "title": "Selling XYLD, proceeds to SCHD",
+    "status": "Decided and in flight. The sale has to settle before the cash can buy SCHD, so for a couple of days this page still shows XYLD as a held position — the numbers below are accurate as of the last snapshot, not as of the decision.",
+    "why": [
+      { "t": "It was redundant", "b": "JEPI already covers S&P 500 covered calls. Two funds were being paid to do one job, and XYLD was the weaker of the two." },
+      { "t": "It has the worst structure in the category", "b": "XYLD writes at-the-money calls on essentially the entire portfolio, which caps upside harder than any alternative. JEPI writes further out through ELNs and keeps more of a rally." },
+      { "t": "It was the QYLG lesson, again", "b": "Same Global X mechanism, same bargain: a headline yield funded by giving away the upside. That lesson already cost money once. Holding XYLD was paying tuition twice." },
+      { "t": "The exit was free, and wouldn't stay that way", "b": "The position was up $10.68 — roughly $1.60 of tax. Every month held, the gain grows and the exit gets more expensive. Cheap exits have a shelf life." },
+      { "t": "Wrong phase of the plan", "b": "Eleven years from retirement with every dividend reinvested, capped upside is the wrong trade. Current income matters at 65, not at 54." },
+      { "t": "SCHD is the better home for the money", "b": "It cuts covered-call concentration from ~28% to ~24%, and SCHD pays qualified dividends where XYLD did not — a meaningful difference in a taxable account." }
+    ],
+    "tradeoff": "This deliberately lowers estimated income by about $79/yr — XYLD paid roughly $116, the same money in SCHD pays about $37. That is the point rather than a side effect: trading current yield for total return and a lower tax bill. It does narrow the dividends-vs-contributions crossover back to a hair above the ~$1,200/yr that gets contributed by hand.",
+    "rule": "Consistent with the standing rules: quality over quantity, don't chase yield, and check SEC yield against distribution yield before holding anything."
+  },
 
   "coreThree": {
     "note": "All new monthly contributions split between these three — together about 39% of the account. SCHD is the clear leader; the summer's contributions went to SCHD and JEPQ, which leaves JEPI as the underweighted one to favor next.",

--- a/_pages/investments.html
+++ b/_pages/investments.html
@@ -82,6 +82,24 @@ full_width: true
         <p>{{ d.meta.oneJob }}</p>
       </div>
 
+      {% if d.pending %}
+      <div class="inv-pending">
+        <div class="inv-pending-head">
+          <span class="inv-pending-tag">Decision in flight</span>
+          <h3>{{ d.pending.title }}</h3>
+          <span class="inv-pending-date">{{ d.pending.date }}</span>
+        </div>
+        <p class="inv-pending-status">{{ d.pending.status }}</p>
+        <ol class="inv-pending-why">
+          {% for r in d.pending.why %}
+          <li><strong>{{ r.t }}.</strong> {{ r.b }}</li>
+          {% endfor %}
+        </ol>
+        <div class="inv-pending-tradeoff"><strong>What it costs:</strong> {{ d.pending.tradeoff }}</div>
+        <p class="inv-pending-rule">{{ d.pending.rule }}</p>
+      </div>
+      {% endif %}
+
       <!-- charts: switchable views -->
       <div class="inv-chartswitch">
         <div class="inv-cs-tabs" role="tablist" aria-label="Chart view">
@@ -158,6 +176,7 @@ full_width: true
               </div>
               <div style="display:flex;flex-direction:column;align-items:flex-end;gap:0.45rem;">
                 <span class="inv-tier-badge">{{ tk | capitalize }}</span>
+                {% if d.pending and d.pending.ticker == h.ticker %}<span class="inv-exit-flag" title="{{ d.pending.status }}">Selling → {{ d.pending.into }}</span>{% endif %}
                 <div class="inv-live" data-live="{{ h.ticker }}"><span class="inv-live-flat">snapshot</span></div>
               </div>
             </div>

--- a/_sass/_investments.scss
+++ b/_sass/_investments.scss
@@ -532,6 +532,50 @@ $inv-mono:    "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
     &.info { background: #eef4fd; border-color: #cfe0f8; color: #1f4f8f; h4 { color: #1f4f8f; } }
   }
 
+  // ── Pending decision (trade decided, not yet settled) ─
+  .inv-pending {
+    background: #fff;
+    border: 1px solid #d9cbef;
+    border-left: 3px solid #6b46c1;
+    border-radius: 4px;
+    padding: 1rem 1.15rem;
+    margin: 1rem 0;
+  }
+  .inv-pending-head {
+    display: flex; align-items: baseline; flex-wrap: wrap; gap: 0.5rem;
+    h3 { margin: 0; font-size: 1rem; color: $inv-ink; }
+  }
+  .inv-pending-tag {
+    font-size: 0.62rem; text-transform: uppercase; letter-spacing: 0.08em;
+    font-weight: 700; color: #fff; background: #6b46c1;
+    padding: 0.15rem 0.45rem; border-radius: 3px;
+  }
+  .inv-pending-date { font-family: $inv-mono; font-size: 0.75rem; color: $inv-faint; margin-left: auto; }
+  .inv-pending-status {
+    margin: 0.55rem 0 0; font-size: 0.83rem; color: $inv-muted; font-style: italic;
+  }
+  .inv-pending-why {
+    margin: 0.8rem 0 0; padding-left: 1.2rem;
+    font-size: 0.85rem; color: $inv-body;
+    li { margin-bottom: 0.4rem; }
+    strong { color: $inv-ink; }
+  }
+  .inv-pending-tradeoff {
+    margin-top: 0.8rem; padding: 0.7rem 0.85rem;
+    background: #faf7ff; border: 1px solid #e6dcf7; border-radius: 3px;
+    font-size: 0.82rem; color: #4c3583;
+  }
+  .inv-pending-rule { margin: 0.7rem 0 0; font-size: 0.76rem; color: $inv-faint; }
+  .inv-exit-flag {
+    font-size: 0.62rem; text-transform: uppercase; letter-spacing: 0.05em;
+    font-weight: 700; color: #6b46c1; background: #f3edfd;
+    border: 1px solid #d9cbef; border-radius: 3px;
+    padding: 0.12rem 0.4rem; white-space: nowrap;
+  }
+  @media (max-width: 720px) {
+    .inv-pending-date { margin-left: 0; width: 100%; }
+  }
+
   // ── Core Three strip ─────────────────────────────────
   .inv-core3 { display: grid; grid-template-columns: repeat(3, 1fr); gap: 0.8rem; margin-top: 0.8rem; }
   .inv-core3-item {


### PR DESCRIPTION
Writes down *why* XYLD is being sold, while the reasoning is fresh.

The sale is decided but not settled, so **XYLD stays in `holdings` and no totals change** — the page would otherwise claim a position that's still held. It renders as a "Decision in flight" panel on the Dashboard, with a `Selling → SCHD` flag on the XYLD sheet, and states plainly that the numbers below still include XYLD.

**The six reasons recorded:** redundant with JEPI · worst structure in the category (ATM calls on the whole portfolio vs JEPI's further-out ELNs) · the QYLG lesson repeating · a free exit with a shelf life ($10.68 gain, ~$1.60 tax) · wrong phase of the plan · SCHD the better home (covered-call concentration ~28% → ~24%, qualified dividends).

**Also records the cost,** since a decision log that only lists upside isn't worth keeping: this drops estimated income ~$79/yr by design ($116 → ~$37), trading current yield for total return and lower tax drag. Worth noting it narrows the dividends-vs-contributions crossover to ~$1,220 against ~$1,200 contributed — still true, just thinner.

When the trade settles, this graduates into a `cleanupDays` entry and XYLD moves to the graveyard.