### PR TITLE
Fix stale-cache CSS masking, and explain AI Notes from the home page

### DIFF
--- a/_includes/ai-notes-explainer.html
+++ b/_includes/ai-notes-explainer.html
@@ -1,0 +1,69 @@
+{%- comment -%}
+  The "Click for AI Notes" pill outside of a post — it explains the feature
+  rather than toggling it, since there are no notes to toggle here. Same shape
+  and colour as the real toggle in _layouts/post.html so the two read as the
+  same thing. Renders the pill and its dialog together; <dialog> paints in the
+  top layer, so it doesn't matter that it sits inside a flex row.
+{%- endcomment -%}
+<button type="button" class="ainotes-explain-btn" aria-haspopup="dialog" aria-controls="ainotes-explainer">
+  <span class="ainotes-ico" aria-hidden="true"><svg viewBox="0 0 24 24"><rect x="4" y="8" width="16" height="11" rx="3" fill="none" stroke="currentColor" stroke-width="1.8"/><circle cx="9.5" cy="13.5" r="1.4" fill="currentColor"/><circle cx="14.5" cy="13.5" r="1.4" fill="currentColor"/><line x1="12" y1="4" x2="12" y2="8" stroke="currentColor" stroke-width="1.8"/><circle cx="12" cy="3" r="1.4" fill="currentColor"/></svg></span>
+  <span>Click for AI Notes</span>
+</button>
+
+<dialog class="ainotes-modal" id="ainotes-explainer" aria-labelledby="ainotes-modal-title">
+  <div class="ainotes-modal-head">
+    <span class="ainotes-ico" aria-hidden="true"><svg viewBox="0 0 24 24"><rect x="4" y="8" width="16" height="11" rx="3" fill="none" stroke="currentColor" stroke-width="1.8"/><circle cx="9.5" cy="13.5" r="1.4" fill="currentColor"/><circle cx="14.5" cy="13.5" r="1.4" fill="currentColor"/><line x1="12" y1="4" x2="12" y2="8" stroke="currentColor" stroke-width="1.8"/><circle cx="12" cy="3" r="1.4" fill="currentColor"/></svg></span>
+    <h2 id="ainotes-modal-title">What are AI Notes?</h2>
+    <button type="button" class="ainotes-modal-close" data-close aria-label="Close">
+      <svg viewBox="0 0 24 24" aria-hidden="true"><line x1="6" y1="6" x2="18" y2="18" stroke="currentColor" stroke-width="2" stroke-linecap="round"/><line x1="18" y1="6" x2="6" y2="18" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg>
+    </button>
+  </div>
+
+  <div class="ainotes-modal-body">
+    <p>Some posts on this site carry <strong>AI Notes</strong> &mdash; short, sourced annotations that add factual context to specific claims in the article.</p>
+
+    <div class="ainotes-modal-how">
+      <p class="ainotes-modal-how-lead">How to use them</p>
+      <p>Open a post and look for this button near the top of the article:</p>
+      <p class="ainotes-modal-demo">
+        <span class="ainotes-explain-btn is-demo" aria-hidden="true">
+          <span class="ainotes-ico"><svg viewBox="0 0 24 24"><rect x="4" y="8" width="16" height="11" rx="3" fill="none" stroke="currentColor" stroke-width="1.8"/><circle cx="9.5" cy="13.5" r="1.4" fill="currentColor"/><circle cx="14.5" cy="13.5" r="1.4" fill="currentColor"/><line x1="12" y1="4" x2="12" y2="8" stroke="currentColor" stroke-width="1.8"/><circle cx="12" cy="3" r="1.4" fill="currentColor"/></svg></span>
+          <span>Click for AI Notes</span>
+        </span>
+      </p>
+      <p>Toggle it on and phrases throughout the article light up. Each one gets a numbered note underneath its paragraph with the relevant fact, a verdict, and a link to where it came from. Not every post has them.</p>
+    </div>
+
+    <p class="ainotes-modal-honest"><strong>Keeping Jason honest.</strong> The notes aren't a victory lap. They confirm a claim when it holds up, supply the date or number the article skipped, and say plainly when something needs more context than it got. A note that disagrees with the post stays in.</p>
+
+    <p>They are <strong>generated entirely by AI</strong> &mdash; not written, curated, fact-checked, or endorsed by me, and they don't necessarily reflect my views. The article stands exactly as written. Treat them as an automated starting point, not gospel: every note links to a source so you can check it yourself. Spot an error? The comments are open.</p>
+  </div>
+
+  <div class="ainotes-modal-foot">
+    <button type="button" class="ainotes-modal-ok" data-close>Got it</button>
+  </div>
+</dialog>
+
+<script>
+  (function () {
+    var btn = document.querySelector('.ainotes-explain-btn[aria-controls="ainotes-explainer"]');
+    var dlg = document.getElementById('ainotes-explainer');
+    if (!btn || !dlg || typeof dlg.showModal !== 'function') return;
+
+    btn.addEventListener('click', function () { dlg.showModal(); });
+
+    dlg.querySelectorAll('[data-close]').forEach(function (el) {
+      el.addEventListener('click', function () { dlg.close(); });
+    });
+
+    // Click outside the panel closes it. showModal() makes the backdrop part of
+    // the dialog itself, so compare against the panel's own box.
+    dlg.addEventListener('click', function (e) {
+      if (e.target !== dlg) return;
+      var r = dlg.getBoundingClientRect();
+      var outside = e.clientX < r.left || e.clientX > r.right ||
+                    e.clientY < r.top  || e.clientY > r.bottom;
+      if (outside) dlg.close();
+    });
+  })();
+</script>

--- a/_includes/ai-notes.html
+++ b/_includes/ai-notes.html
@@ -5,4 +5,4 @@
 {%- endfor -%}
 ]
 </script>
-<script src="{{ '/assets/js/ai-notes.js' | relative_url }}" defer></script>
+<script src="{{ '/assets/js/ai-notes.js' | relative_url }}?v={{ site.time | date: '%s' }}" defer></script>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -8,7 +8,13 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Nunito+Sans:wght@200;300;400;600;700&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="{{ '/assets/css/main.css' | relative_url }}">
+  {%- comment -%}
+    ?v= is the build timestamp. /assets/css/main.css is served with
+    cache-control: max-age=600 and no fingerprint in the filename, so without
+    this a browser can hold a stale stylesheet for ten minutes after a deploy
+    and render new markup against old CSS.
+  {%- endcomment -%}
+  <link rel="stylesheet" href="{{ '/assets/css/main.css' | relative_url }}?v={{ site.time | date: '%s' }}">
   <link rel="alternate" type="application/atom+xml" title="{{ site.title }}" href="{{ '/feed.xml' | relative_url }}">
 </head>
 <body>

--- a/_sass/_ai-notes.scss
+++ b/_sass/_ai-notes.scss
@@ -16,7 +16,8 @@
 }
 
 // ── Toggle button (lives in .post-actions, on the light body background) ──
-.post-ainotes-btn {
+.post-ainotes-btn,
+.ainotes-explain-btn {
   display: inline-flex;
   align-items: center;
   gap: .45rem;
@@ -33,7 +34,8 @@
   cursor: pointer;
   transition: background .15s ease, border-color .15s ease, color .15s ease, box-shadow .15s ease;
 
-  .post-ainotes-ico {
+  .post-ainotes-ico,
+  .ainotes-ico {
     display: inline-flex;
     width: 17px;
     height: 17px;
@@ -47,11 +49,12 @@
     box-shadow: 0 1px 4px rgba(0, 0, 0, .08);
   }
 
-  &.is-on {
-    background: #ffd21e;
-    border-color: #ffd21e;
-    color: #1a1a1a;
-  }
+}
+
+.post-ainotes-btn.is-on {
+  background: #ffd21e;
+  border-color: #ffd21e;
+  color: #1a1a1a;
 }
 
 // ── Injected bubbles ── (scoped to post body)
@@ -235,4 +238,159 @@
 
   .ai-notes-about p { margin: 0; }
   .ai-notes-about strong { color: #4a4227; }
+}
+
+
+// ── "What are AI Notes?" explainer modal ──
+// Opened from the pill on the home page. Native <dialog>, so Esc and focus
+// trapping come free; the JS only adds open, close, and click-outside.
+.ainotes-explain-btn.is-demo {
+  cursor: default;
+  pointer-events: none;
+  vertical-align: middle;
+}
+
+.ainotes-modal {
+  width: min(38rem, calc(100vw - 2rem));
+  max-height: min(85vh, 46rem);
+  padding: 0;
+  border: 1px solid #e6cf6a;
+  border-radius: 14px;
+  background: #fff;
+  color: #333;
+  box-shadow: 0 24px 60px -20px rgba(0, 0, 0, .45);
+  overflow: hidden;
+
+  &::backdrop {
+    background: rgba(20, 22, 28, .55);
+    backdrop-filter: blur(2px);
+  }
+
+  &[open] {
+    display: flex;
+    flex-direction: column;
+    animation: ainotes-modal-in .18s ease-out;
+  }
+}
+
+@keyframes ainotes-modal-in {
+  from { opacity: 0; transform: translateY(6px) scale(.985); }
+  to   { opacity: 1; transform: none; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ainotes-modal[open] { animation: none; }
+}
+
+.ainotes-modal-head {
+  display: flex;
+  align-items: center;
+  gap: .6rem;
+  padding: 1rem 1.15rem;
+  border-bottom: 1px solid #f1dd85;
+  background: #fffbea;
+  color: #6b5400;
+
+  .ainotes-ico {
+    display: inline-flex;
+    flex: 0 0 auto;
+    width: 26px;
+    height: 26px;
+    padding: 4px;
+    border-radius: 50%;
+    background: #ffd21e;
+    color: #1a1a1a;
+
+    svg { width: 18px; height: 18px; }
+  }
+
+  h2 {
+    flex: 1 1 auto;
+    margin: 0;
+    font-size: 1.05rem;
+    font-weight: 800;
+    color: #4a3a00;
+  }
+}
+
+.ainotes-modal-close {
+  flex: 0 0 auto;
+  display: grid;
+  place-items: center;
+  width: 30px;
+  height: 30px;
+  padding: 0;
+  border: 1px solid transparent;
+  border-radius: 50%;
+  background: none;
+  color: #6b5400;
+  cursor: pointer;
+  transition: background .15s ease, border-color .15s ease;
+
+  svg { width: 17px; height: 17px; }
+
+  &:hover { background: #fff4c2; border-color: #e6cf6a; }
+  &:focus-visible { outline: 2px solid #2673da; outline-offset: 2px; }
+}
+
+.ainotes-modal-body {
+  flex: 1 1 auto;
+  overflow-y: auto;
+  padding: 1.15rem;
+  font-size: .95rem;
+  line-height: 1.65;
+
+  p { margin: 0 0 .9rem; }
+  p:last-child { margin-bottom: 0; }
+  strong { font-weight: 800; }
+}
+
+.ainotes-modal-how {
+  margin: 0 0 .9rem;
+  padding: .85rem 1rem;
+  border: 1px solid #f1dd85;
+  border-left: 4px solid #ffd21e;
+  border-radius: 10px;
+  background: #fffbea;
+  color: #3a3320;
+
+  .ainotes-modal-how-lead {
+    margin-bottom: .45rem;
+    font-weight: 800;
+    color: #4a3a00;
+  }
+}
+
+.ainotes-modal-demo {
+  margin: .7rem 0 .8rem;
+}
+
+.ainotes-modal-honest {
+  padding-left: .85rem;
+  border-left: 3px solid #ddd;
+}
+
+.ainotes-modal-foot {
+  flex: 0 0 auto;
+  display: flex;
+  justify-content: flex-end;
+  padding: .85rem 1.15rem;
+  border-top: 1px solid #eee;
+  background: #fafafa;
+}
+
+.ainotes-modal-ok {
+  padding: .45rem 1.1rem;
+  border: 1px solid #e6cf6a;
+  border-radius: 999px;
+  background: #ffd21e;
+  color: #1a1a1a;
+  font: inherit;
+  font-size: .85rem;
+  font-weight: 700;
+  cursor: pointer;
+  transition: background .15s ease, box-shadow .15s ease;
+
+  &:hover { background: #ffdc4d; box-shadow: 0 1px 4px rgba(0, 0, 0, .12); }
+  &:focus-visible { outline: 2px solid #2673da; outline-offset: 2px; }
 }

--- a/_sass/_layout.scss
+++ b/_sass/_layout.scss
@@ -227,6 +227,17 @@
 }
 
 // ── "Most Recent Blog Posts" heading ────────────────────
+// The heading shares a row with the AI Notes explainer pill, which sits hard
+// right. Baseline alignment keeps the pill on the heading's text baseline
+// rather than centring it against the underline bar the h2 draws below itself.
+.recent-posts-head {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.5rem 1rem;
+}
+
 .recent-posts-heading {
   font-size: 1.45rem;
   font-weight: 700;

--- a/index.html
+++ b/index.html
@@ -19,7 +19,10 @@ full_width: true
   <div class="sub-hero" aria-hidden="true"></div>
 
   <div class="site-wrapper">
-    <h2 class="recent-posts-heading">Most Recent Blog Posts</h2>
+    <div class="recent-posts-head">
+      <h2 class="recent-posts-heading">Most Recent Blog Posts</h2>
+      {% include ai-notes-explainer.html %}
+    </div>
     <div class="post-grid">
       {% for post in paginator.posts %}
       <a class="post-card" href="{{ post.url | relative_url }}">


### PR DESCRIPTION
Two things: the highlight bug reported on the live site, and the home-page AI Notes explainer.

## The bright-yellow highlight

`::highlight::` was rendering as flat `rgb(255,255,0)` with no gradient. It was not a missing class or a bad selector — everything on the server was already correct:

- live `main.css` contained the Legal Pad gradient and was **byte-identical** to a local build (100,945 bytes)
- live HTML contained `<mark class="hl">`
- only one stylesheet on the page, no inline overrides
- no competing `mark` rules anywhere in `_sass/`
- `ai-notes.js` wraps anchors in `span.ai-note-anchor`, not `<mark>`

The actual cause was caching:

```
cache-control: max-age=600
last-modified: Mon, 24 Aug 2026 13:51:28 GMT
```

`/assets/css/main.css` carries no fingerprint, so a browser could hold the pre-deploy stylesheet for ten minutes while already having the new HTML. `<mark>` then fell back to the user-agent default, which is exactly `rgb(255,255,0)` with no gradient.

Appending the build timestamp gives every deploy a fresh URL, so a CSS change can never be masked this way again. Applied to `ai-notes.js` too.

## Home-page AI Notes explainer

The same yellow pill now sits hard right of **Most Recent Blog Posts**. There are no notes to toggle there, so it opens a dialog covering what AI Notes are, how to find them inside a post (with an inline picture of the button to look for), and what they are for.

The copy keeps the honest framing: notes confirm a claim when it holds up, supply what the article skipped, and say when something needs more context — and a note that disagrees with the post stays in. It repeats that the notes are AI-generated, unvetted, and not endorsed.

Implementation notes:

- The pill shape is now shared between the real toggle and this one, so they read as the same control. `.is-on` moved to its own selector since the toggled state belongs only to the real button — verified the post toggle still compiles to `.post-ainotes-btn.is-on{...}`.
- Native `<dialog>`, so Esc and focus trapping come free; the script only adds open, close, and click-outside.
- Reusable include, not inlined into `index.html`.

## Verified

- Build clean; `main.css?v=…` and `ai-notes.js?v=…` both emitted
- Pill, dialog, and wiring present in rendered `index.html`; modal JS passes `node --check`
- Post toggle markup and `.is-on` styling unchanged

Worth a hard refresh when this deploys — the whole point is that it's the last time that should be necessary.