### PR TITLE
Centre the AI Notes modal

### DIFF
--- a/_sass/_ai-notes.scss
+++ b/_sass/_ai-notes.scss
@@ -251,6 +251,11 @@
 }
 
 .ainotes-modal {
+  // The browser centres a modal <dialog> with `inset: 0` plus `margin: auto`,
+  // but the `* { margin: 0 }` reset in _base.scss is an author style and so
+  // beats the UA stylesheet — which leaves inset:0 with no centring and pins
+  // the dialog to the top-left. Restore the auto margins explicitly.
+  margin: auto;
   width: min(38rem, calc(100vw - 2rem));
   max-height: min(85vh, 46rem);
   padding: 0;


### PR DESCRIPTION
Follow-up to #37, which merged before this landed. As currently on `main`, the explainer modal opens pinned to the top-left corner instead of centred.

## Cause

A modal `<dialog>` is centred by the browser's `dialog:modal` UA rule, which combines `inset: 0` with `margin: auto`. The reset in `_sass/_base.scss`:

```css
* { box-sizing: border-box; margin: 0; padding: 0; }
```

is an author style, so it beats the UA stylesheet regardless of specificity. That kills the `auto` margins and leaves `inset: 0` with nothing centring it — which parks the dialog in the top-left. That corner is the signature of this exact interaction.

## Fix

Restore the auto margins explicitly on `.ainotes-modal`, handing centring back to the browser rather than hand-rolling a transform.

## Worth knowing

This is not specific to this modal. **Any native `<dialog>` added to this site will open top-left for the same reason**, along with anything else relying on the UA stylesheet's auto margins. I left a comment on the rule so it doesn't have to be rediscovered next time.

Verified on a local server before and after: top-left before, centred after, build clean.